### PR TITLE
Fix: Remove deprecated license classifier for setuptools 78+ compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,18 +30,14 @@ dependencies = [
     "aiohttp>=3.13.3",  # Security: Fixes CVE-2025-69223 through CVE-2025-69230
     "einops>=0.8.0",  # Required for CodeRankEmbed model
     "faiss-cpu>=1.13.1",
-    "FlagEmbedding>=1.3.0",
     "fsspec[http]>=2024.2.0,<=2025.10.0",  # Upper bound: datasets 4.4.2 constraint
     "huggingface-hub>=0.36.0",
     "mcp>=1.25.0",
     "networkx>=3.0",  # Required for graph storage and community detection
     "nltk>=3.8",
-    "pandas>=2.0.0",  # Required by datasets (transitive dependency of sentence-transformers)
     "psutil>=7.2.1",
     "rank-bm25>=0.2.2",
     "torch>=2.8.0,<2.9.0",  # 2.9.x breaks ModernBERT torch.compile (template conflict)
-    "torchvision>=0.23.0,<0.24.0",
-    "torchaudio>=2.8.0,<2.9.0",
     "rich>=14.2.0",
     "sentence-transformers>=5.2.0",
     "transformers>=4.57.3",  # Required for Qwen3-0.6B support
@@ -62,7 +58,6 @@ dependencies = [
 
 classifiers = [
     "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -80,8 +75,6 @@ test = [
     "pytest-repeat>=0.9.3",
 ]
 dev = [
-    "black>=25.11.0",
-    "isort>=7.0.0",
     "ruff>=0.14.10",
     "pip-audit>=2.10.0",
     "pip-licenses>=5.5.0",
@@ -102,7 +95,7 @@ include = ["chunking*", "embeddings*", "mcp_server*", "search*", "merkle*"]
 # Security: Minimum versions for CVE fixes
 # Direct dependencies: Updated in dependencies list above
 # Transitive dependencies: Installed automatically, documented here for tracking
-# Last audit: 2026-01-03 (pip-audit - 0 vulnerabilities)
+# Last audit: 2026-01-30 (pip-audit - 0 vulnerabilities)
 #
 # Direct dependency security updates:
 # mcp>=1.25.0        # Fixes CVE-2025-66416 (DNS rebinding vulnerability)
@@ -110,9 +103,11 @@ include = ["chunking*", "embeddings*", "mcp_server*", "search*", "merkle*"]
 # Transitive dependency security updates:
 # authlib>=1.6.5     # Fixes CVE-2025-59420, CVE-2025-61920, CVE-2025-62706
 # pip>=25.3          # Fixes CVE-2025-8869 (tarfile path traversal)
+# python-multipart>=0.0.22  # Fixes CVE-2026-24486 (path traversal in file uploads)
 # starlette>=0.51.0  # Fixes CVE (version: 0.47.3 → 0.51.0)
 # uv>=0.9.6          # Fixes 2 CVEs (version: 0.8.21 → 0.9.6)
 # werkzeug>=3.1.4    # Fixes CVE-2025-66221 (Windows device name handling)
+# wheel>=0.46.2      # Fixes CVE-2026-24049 (path traversal in unpack)
 #
 # Verification: .venv/Scripts/pip-audit --format json | .venv/Scripts/python.exe tools/summarize_audit.py
 #
@@ -120,7 +115,7 @@ include = ["chunking*", "embeddings*", "mcp_server*", "search*", "merkle*"]
 # fsspec[http]<=2025.10.0  # Now pinned as direct dep - prevents deepspeed conflict
 # sympy>=1.13.1            # torch 2.8.x requires sympy (version may vary)
 # huggingface-hub<1.0 # transformers 4.57.3 requires huggingface-hub>=0.34.0,<1.0
-# numpy<2.4.0         # Multiple packages constrain numpy (faiss, scipy, pandas, etc.)
+# numpy<2.4.0         # Multiple packages constrain numpy (faiss, scipy, etc.)
 # torch>=2.8.0,<2.9.0 # 2.9.x breaks ModernBERT torch.compile (inductor template conflict on Windows)
 #
 # Successfully updated dependencies (tested 2026-01-03):
@@ -140,6 +135,17 @@ include = ["chunking*", "embeddings*", "mcp_server*", "search*", "merkle*"]
 # protobuf (6.33.2→6.33.4), starlette (0.50.0→0.51.0), tomli (2.3.0→2.4.0), uv (0.9.23→0.9.24)
 # Tested: 1387/1414 unit tests passed, 7/8 integration tests passed
 # Known pre-existing failures: 16 unit test failures + 11 errors (unrelated to updates)
+#
+# CVE security updates (tested 2026-01-29):
+# python-multipart (0.0.21→0.0.22), wheel (0.45.1→0.46.2)
+# Safe patches: coverage (7.13.1→7.13.2), cryptography (46.0.3→46.0.4), librt (0.7.7→0.7.8)
+# Safe patches: mcp (1.25.0→1.26.0), nvidia-ml-py (13.590.44→13.590.48), pip-licenses (5.5.0→5.5.1)
+# Safe patches: psutil (7.2.1→7.2.2), pyparsing (3.3.1→3.3.2), pytokens (0.3.0→0.4.0)
+# Safe patches: rich (14.2.0→14.3.1), ruff (0.14.11→0.14.14), sentence-transformers (5.2.0→5.2.2)
+# Safe patches: setuptools (80.10.1→80.10.2), soupsieve (2.8.1→2.8.3), sse-starlette (3.1.2→3.2.0)
+# Safe patches: starlette (0.51.0→0.52.1), uv (0.9.24→0.9.27), wcwidth (0.2.14→0.5.0)
+# Tested: 656/657 unit tests passed (1 pre-existing failure), CUDA verified, pip check passed
+# Remaining CVEs: 0 (all resolved as of 2026-01-30)
 
 [tool.uv]
 index-url = "https://pypi.org/simple"
@@ -160,34 +166,8 @@ explicit = true
 torch = [
     { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-torchvision = [
-    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
-torchaudio = [
-    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-]
 
 # Code quality tools configuration
-[tool.black]
-line-length = 88
-target-version = ["py311"]
-exclude = '''
-/(
-    \.git
-  | \.venv
-  | _archive
-  | build
-  | dist
-  | node_modules
-)/
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 88
-skip_glob = ["_archive/*", ".venv/*"]
-known_first_party = ["chunking", "embeddings", "mcp_server", "search", "merkle", "evaluation"]
-
 [tool.ruff]
 line-length = 88
 target-version = "py311"


### PR DESCRIPTION
## Problem

All PRs targeting `main` (#3, #4, #5) fail CI at `pip install -e .[test]` with:

```
setuptools.errors.InvalidConfigError: License classifiers have been superseded
by license expressions (see https://peps.python.org/pep-0639/).
Please remove: License :: OSI Approved :: Apache Software License
```

## Root Cause

The `main` branch `pyproject.toml` has:
- ✅ Line 11: `license = "Apache-2.0"` (PEP 639 expression — correct)
- ❌ Line 64: `"License :: OSI Approved :: Apache Software License"` classifier (conflicts with above)

GitHub Actions runners use `setuptools>=80.10` which strictly enforces PEP 639, rejecting the old-style license classifier when a license expression is present.

## Changes

Sync `pyproject.toml` with `development` branch:

### License Fix (critical)
- ❌ Remove `"License :: OSI Approved :: Apache Software License"` classifier

### Dependency Cleanup
- Remove stale deps: `FlagEmbedding`, `pandas`, `torchvision`, `torchaudio`
- Remove stale dev tools: `black`, `isort`
- Remove stale UV sources and tool configs

### Documentation
- Update security audit comments (2026-01-29)
- Document remaining CVEs: 0 (all resolved)

## Impact

✅ Unblocks PRs #3, #4, #5 — CI will pass `pip install -e .[test]` step
✅ No functional changes (dependencies already not used in codebase)
✅ Aligns `main` with `development` for smoother merges

## Verification

- PR CI should successfully complete `pip install -e .[test]`
- After merge, rerun CI on #3, #4, #5 (push empty commits to retrigger if needed)

**Priority**: URGENT — blocks 3 open PRs from merging