### PR TITLE
feat: ONNX Runtime inference support — core + tests + early fixes

### DIFF
--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -1304,9 +1304,22 @@ class CodeEmbedder:
         Returns GPU memory allocated by the model in gigabytes.
         Used for dynamic batch size calculation to avoid using registry estimates.
 
+        For ONNX models: PyTorch's allocator reports 0 because ORT's
+        CUDAExecutionProvider allocates CUDA memory outside PyTorch. ModelLoader
+        stores the pynvml before/after delta on the wrapper as `_vram_gb` instead.
+
         Returns:
             Model VRAM usage in GB, or 0.0 if GPU not available
         """
+        # ONNX path: use measured ORT allocation delta (set by ModelLoader._load_onnx)
+        if (
+            self._model is not None
+            and hasattr(self._model, "_vram_gb")
+            and self._model._vram_gb > 0
+        ):
+            return self._model._vram_gb
+
+        # PyTorch path
         if torch is None or not torch.cuda.is_available():
             return 0.0
 
@@ -1329,8 +1342,20 @@ class CodeEmbedder:
             try:
                 import gc
 
-                # Step 1: Move model to CPU (frees VRAM immediately)
-                if torch is not None and torch.cuda.is_available():
+                # Step 1: Free GPU memory.
+                # ONNX path: call cleanup() to explicitly destroy the ORT CUDA session,
+                # which is the only way to release CUDA memory allocated by ORT's
+                # CUDAExecutionProvider (not tracked by torch.cuda.memory_allocated).
+                # PyTorch path: move to CPU first to free VRAM, then delete.
+                if hasattr(self._model, "cleanup"):
+                    self._logger.info("Releasing ONNX Runtime CUDA session...")
+                    self._model.cleanup()
+                    self._logger.info("ONNX VRAM freed")
+                elif (
+                    torch is not None
+                    and torch.cuda.is_available()
+                    and hasattr(self._model, "cpu")
+                ):
                     self._logger.info("Moving model from GPU to CPU...")
                     self._model = self._model.cpu()
                     torch.cuda.synchronize()  # Wait for GPU operations

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -333,9 +333,18 @@ class ModelLoader:
             ValueError: If model not found on HuggingFace Hub
             RuntimeError: If model loading fails after all recovery attempts
         """
-        # ONNX fast path — bypasses PyTorch loading entirely when enabled
+        # ONNX fast path — bypasses PyTorch loading entirely when enabled.
+        # If optimum[onnxruntime] is not installed (optional dep), ONNX load
+        # raises ImportError from onnx_loader._convert_model(); catch it and
+        # fall through to the PyTorch path so fresh installs without the ONNX
+        # extra don't hard-fail on first model load.
         if self._should_use_onnx():
-            return self._load_onnx()
+            try:
+                return self._load_onnx()
+            except ImportError as e:
+                self._logger.warning(
+                    f"[ONNX] Falling back to PyTorch — optimum not installed: {e}"
+                )
 
         if SentenceTransformer is None:
             raise ImportError(

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -220,6 +220,64 @@ class ModelLoader:
 
         return kwargs
 
+    def _should_use_onnx(self) -> bool:
+        """Return True if ONNX is enabled in config and this model is eligible.
+
+        Eligibility requires:
+        - use_onnx=True in performance config
+        - Model does NOT require trust_remote_code (custom architectures unsupported)
+        """
+        try:
+            from mcp_server.utils.config_helpers import (
+                get_config_via_service_locator as _get_config,
+            )
+
+            config = _get_config()
+            if not config or not getattr(config.performance, "use_onnx", False):
+                return False
+        except Exception:
+            return False
+
+        model_config = self._get_model_config()
+        if model_config.get("trust_remote_code", False):
+            self._logger.debug(
+                f"[ONNX] Skipping {self.model_name!r}: trust_remote_code=True"
+            )
+            return False
+        return True
+
+    def _load_onnx(self) -> tuple[Any, str]:
+        """Load model via ONNX Runtime, auto-converting from HuggingFace if needed.
+
+        Returns:
+            Tuple of (ONNXEmbeddingModel, resolved_device)
+        """
+        from embeddings.onnx_loader import ONNXModelLoader
+        from embeddings.onnx_wrapper import ONNXEmbeddingModel
+
+        model_config = self._get_model_config()
+        pooling = model_config.get("onnx_pooling", "cls")
+
+        loader = ONNXModelLoader(
+            model_name=self.model_name,
+            cache_dir=self.cache_dir,
+            device=self.device,
+        )
+        ort_model, tokenizer, device = loader.load()
+
+        wrapper = ONNXEmbeddingModel(
+            ort_model=ort_model,
+            tokenizer=tokenizer,
+            device=device,
+            pooling=pooling,
+            model_name=self.model_name,
+        )
+        self._logger.info(
+            f"Model loaded successfully on device: {device} "
+            f"[backend=onnxruntime, pooling={pooling}]"
+        )
+        return wrapper, device
+
     def load(self) -> tuple[Any, str]:
         """Load model with automatic cache corruption recovery and fallback.
 
@@ -231,6 +289,10 @@ class ModelLoader:
             ValueError: If model not found on HuggingFace Hub
             RuntimeError: If model loading fails after all recovery attempts
         """
+        # ONNX fast path — bypasses PyTorch loading entirely when enabled
+        if self._should_use_onnx():
+            return self._load_onnx()
+
         if SentenceTransformer is None:
             raise ImportError(
                 "sentence-transformers not found. Install with: "

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -30,6 +30,25 @@ from mcp_server.utils.config_helpers import (
 )
 
 
+def _get_nvml_used_bytes() -> int:
+    """Return total GPU memory used (bytes) via NVML, or 0 on failure.
+
+    Used to take before/after snapshots around ONNX model loads so that
+    ORT's CUDAExecutionProvider allocations (invisible to PyTorch) can be
+    measured and reported to the dynamic batch-size calculator.
+    """
+    try:
+        import pynvml
+
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        pynvml.nvmlShutdown()
+        return mem.used
+    except Exception:
+        return 0
+
+
 class ModelLoader:
     """Handles loading and device management for embedding models.
 
@@ -258,12 +277,20 @@ class ModelLoader:
         model_config = self._get_model_config()
         pooling = model_config.get("onnx_pooling", "cls")
 
+        # Snapshot real VRAM before ORT session creation. ORT's CUDAExecutionProvider
+        # allocates CUDA memory outside PyTorch — torch.cuda.memory_allocated() stays 0.
+        # A before/after delta gives the true model footprint for batch-size calculation.
+        pre_vram_bytes = _get_nvml_used_bytes()
+
         loader = ONNXModelLoader(
             model_name=self.model_name,
             cache_dir=self.cache_dir,
             device=self.device,
         )
         ort_model, tokenizer, device = loader.load()
+
+        post_vram_bytes = _get_nvml_used_bytes()
+        vram_delta_gb = max(0.0, (post_vram_bytes - pre_vram_bytes) / (1024**3))
 
         wrapper = ONNXEmbeddingModel(
             ort_model=ort_model,
@@ -272,9 +299,13 @@ class ModelLoader:
             pooling=pooling,
             model_name=self.model_name,
         )
+        wrapper._vram_gb = (
+            vram_delta_gb  # used by _get_model_vram_gb() for batch sizing
+        )
+
         self._logger.info(
             f"Model loaded successfully on device: {device} "
-            f"[backend=onnxruntime, pooling={pooling}]"
+            f"[backend=onnxruntime, pooling={pooling}, vram={vram_delta_gb:.2f}GB]"
         )
         return wrapper, device
 

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -30,18 +30,31 @@ from mcp_server.utils.config_helpers import (
 )
 
 
-def _get_nvml_used_bytes() -> int:
+def _get_nvml_used_bytes(device: str = "cuda:0") -> int:
     """Return total GPU memory used (bytes) via NVML, or 0 on failure.
 
     Used to take before/after snapshots around ONNX model loads so that
     ORT's CUDAExecutionProvider allocations (invisible to PyTorch) can be
     measured and reported to the dynamic batch-size calculator.
+
+    Args:
+        device: PyTorch device string (e.g. "cuda:0", "cuda:1", "cuda").
+            The integer index is parsed from after the colon; bare "cuda"
+            and non-cuda strings fall back to index 0.
     """
     try:
         import pynvml
 
+        # Parse device index from "cuda:N"; default to 0 for "cuda"/"cpu"/"auto"/etc.
+        idx = 0
+        if ":" in device:
+            try:
+                idx = int(device.split(":", 1)[1])
+            except ValueError:
+                idx = 0
+
         pynvml.nvmlInit()
-        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        handle = pynvml.nvmlDeviceGetHandleByIndex(idx)
         mem = pynvml.nvmlDeviceGetMemoryInfo(handle)
         pynvml.nvmlShutdown()
         return mem.used
@@ -280,7 +293,7 @@ class ModelLoader:
         # Snapshot real VRAM before ORT session creation. ORT's CUDAExecutionProvider
         # allocates CUDA memory outside PyTorch — torch.cuda.memory_allocated() stays 0.
         # A before/after delta gives the true model footprint for batch-size calculation.
-        pre_vram_bytes = _get_nvml_used_bytes()
+        pre_vram_bytes = _get_nvml_used_bytes(self.device)
 
         loader = ONNXModelLoader(
             model_name=self.model_name,
@@ -289,7 +302,7 @@ class ModelLoader:
         )
         ort_model, tokenizer, device = loader.load()
 
-        post_vram_bytes = _get_nvml_used_bytes()
+        post_vram_bytes = _get_nvml_used_bytes(device)
         vram_delta_gb = max(0.0, (post_vram_bytes - pre_vram_bytes) / (1024**3))
 
         wrapper = ONNXEmbeddingModel(

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -230,9 +230,17 @@ class ONNXModelLoader:
             f"[ONNX] Loading {self.model_name!r} from {self._onnx_dir} via {provider}"
         )
         try:
+            import onnxruntime as ort
+
+            session_options = ort.SessionOptions()
+            # Suppress Memcpy/shape-op assignment warnings — ORT intentionally
+            # assigns shape-related ops to CPU; the messages are noise, not errors.
+            session_options.log_severity_level = 3  # ERROR only (0=VERBOSE, 3=ERROR)
+
             ort_model = ORTModelForFeatureExtraction.from_pretrained(
                 str(self._onnx_dir),
                 provider=provider,
+                session_options=session_options,
             )
             try:
                 tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -234,7 +234,11 @@ class ONNXModelLoader:
                 str(self._onnx_dir),
                 provider=provider,
             )
-            tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
+            except Exception:
+                # Unoptimized fallback exports may not have tokenizer files in the ONNX dir
+                tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         except Exception as e:
             raise RuntimeError(
                 f"[ONNX] Failed to load from {self._onnx_dir}: {e}\n"

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -1,0 +1,245 @@
+"""ONNX model loader with auto-conversion for claude-context-local.
+
+On first use with use_onnx=True, converts the model to ONNX using the same
+pipeline as tools/convert_onnx.py, then caches the result. Subsequent loads
+skip conversion and read directly from cache.
+
+Cache layout:
+    ~/.cache/huggingface/onnx/<org>--<model>/
+        model_optimized.onnx      ← optimized ONNX graph
+        tokenizer.json            ← HuggingFace tokenizer
+        tokenizer_config.json
+        convert_meta.json         ← conversion metadata (model, date, quality)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+_log = logging.getLogger(__name__)
+
+# Default optimization level — O4 = maximum transformer-specific fusions
+_DEFAULT_OPTIMIZE = "O4"
+# GEMM GELU fusion is more numerically stable than gelu_approximation
+# (max diff 0.0004 vs 0.0011 per the Optimum benchmark notebook)
+_GEMM_GELU = True
+
+
+def _onnx_cache_dir(model_name: str) -> Path:
+    """Return canonical ONNX cache path for a model.
+
+    Mirrors the convention used by tools/convert_onnx.py:
+        ~/.cache/huggingface/onnx/BAAI--bge-m3/
+    """
+    sanitized = model_name.replace("/", "--")
+    return Path.home() / ".cache" / "huggingface" / "onnx" / sanitized
+
+
+def _is_converted(onnx_dir: Path) -> bool:
+    """True if a valid converted ONNX model exists at onnx_dir."""
+    meta = onnx_dir / "convert_meta.json"
+    # Accept both the optimized and base filenames
+    model_exists = (onnx_dir / "model_optimized.onnx").is_file() or (
+        onnx_dir / "model.onnx"
+    ).is_file()
+    return meta.is_file() and model_exists
+
+
+def _resolve_provider(device: str) -> str:
+    if device == "cuda":
+        return "CUDAExecutionProvider"
+    return "CPUExecutionProvider"
+
+
+def _convert_model(model_name: str, onnx_dir: Path, device: str) -> None:
+    """Export and optimize a model to ONNX.
+
+    Uses the notebook-proven pattern:
+      1. ORTModelForFeatureExtraction.from_pretrained(model, export=True)
+      2. ORTOptimizer with AutoOptimizationConfig.O4() + GEMM GELU fusion
+
+    Args:
+        model_name: HuggingFace model name.
+        onnx_dir: Target directory for the converted model.
+        device: "cuda" or "cpu".
+
+    Raises:
+        ImportError: If optimum is not installed.
+        RuntimeError: If export or optimization fails.
+    """
+    try:
+        from optimum.onnxruntime import (
+            AutoOptimizationConfig,
+            ORTModelForFeatureExtraction,
+            ORTOptimizer,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "optimum[onnxruntime-gpu] is required for ONNX inference.\n"
+            "Install with:  uv pip install -e .[onnx]\n"
+            "           or: pip install optimum[onnxruntime-gpu]\n"
+            "To disable ONNX, set use_onnx: false in search_config.json."
+        ) from e
+
+    provider = _resolve_provider(device)
+    onnx_dir.mkdir(parents=True, exist_ok=True)
+
+    _log.info(f"[ONNX] Auto-converting {model_name!r} (first run, one-time cost)...")
+    _log.info(f"[ONNX] Output: {onnx_dir}")
+
+    # Step 1: Export to ONNX
+    _log.info("[ONNX] Step 1/2: Exporting model to ONNX...")
+    try:
+        ort_model = ORTModelForFeatureExtraction.from_pretrained(
+            model_name,
+            export=True,
+            provider=provider,
+        )
+    except Exception as e:
+        raise RuntimeError(
+            f"[ONNX] Export failed for {model_name!r}: {e}\n"
+            "The model architecture may not be supported by optimum for ONNX export.\n"
+            "Set use_onnx: false in search_config.json to use PyTorch instead."
+        ) from e
+
+    # Step 2: Apply O4 optimization + GEMM GELU fusion
+    _log.info(f"[ONNX] Step 2/2: Applying {_DEFAULT_OPTIMIZE} + GEMM GELU fusion...")
+    try:
+        optimizer = ORTOptimizer.from_pretrained(ort_model)
+        opt_config_cls = getattr(AutoOptimizationConfig, _DEFAULT_OPTIMIZE)
+        optimization_config = opt_config_cls()
+        optimization_config.enable_gelu_approximation = False
+        optimization_config.enable_gemm_fast_gelu_fusion = _GEMM_GELU
+        optimizer.optimize(
+            save_dir=str(onnx_dir),
+            optimization_config=optimization_config,
+        )
+    except Exception as e:
+        raise RuntimeError(f"[ONNX] Optimization failed: {e}") from e
+
+    # Write metadata
+    try:
+        import optimum
+
+        optimum_version = optimum.__version__
+    except Exception:
+        optimum_version = "unknown"
+
+    model_file = (
+        "model_optimized.onnx"
+        if (onnx_dir / "model_optimized.onnx").is_file()
+        else "model.onnx"
+    )
+    meta: dict[str, Any] = {
+        "source_model": model_name,
+        "optimization_level": _DEFAULT_OPTIMIZE,
+        "gemm_gelu_fusion": _GEMM_GELU,
+        "device": device,
+        "provider": provider,
+        "converted_at": datetime.now(UTC).isoformat(),
+        "optimum_version": optimum_version,
+        "model_file": model_file,
+        "quality_validated": False,
+    }
+    (onnx_dir / "convert_meta.json").write_text(json.dumps(meta, indent=2))
+    _log.info(f"[ONNX] Conversion complete → {onnx_dir}")
+
+
+class ONNXModelLoader:
+    """Loads ONNX embedding models, auto-converting from HuggingFace on first use.
+
+    On the first call to load() with a model that hasn't been converted yet,
+    performs the export + O4 optimization (a one-time cost). Subsequent loads
+    read directly from the ONNX cache.
+
+    Args:
+        model_name: HuggingFace model name (e.g. "BAAI/bge-m3").
+        cache_dir: HuggingFace model cache directory (used for fallback tokenizer lookup).
+        device: Inference device — "cuda", "cpu", or "auto".
+        onnx_cache_dir: Optional override for the ONNX output directory.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        cache_dir: str | None = None,
+        device: str = "auto",
+        onnx_cache_dir: Path | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.cache_dir = cache_dir
+        self._raw_device = device
+        self._onnx_dir = onnx_cache_dir or _onnx_cache_dir(model_name)
+
+    def _resolve_device(self) -> str:
+        if self._raw_device != "auto":
+            return self._raw_device
+        try:
+            import torch
+
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            return "cpu"
+
+    @property
+    def onnx_dir(self) -> Path:
+        return self._onnx_dir
+
+    def is_converted(self) -> bool:
+        """Return True if a valid ONNX model is already cached."""
+        return _is_converted(self._onnx_dir)
+
+    def convert_if_needed(self, device: str) -> None:
+        """Run conversion if the ONNX model doesn't exist yet."""
+        if not _is_converted(self._onnx_dir):
+            _convert_model(self.model_name, self._onnx_dir, device)
+
+    def load(self) -> tuple[Any, Any, str]:
+        """Load the ONNX model, auto-converting from HuggingFace if needed.
+
+        Returns:
+            Tuple of (ort_model, tokenizer, resolved_device).
+
+        Raises:
+            ImportError: If optimum is not installed and conversion is needed.
+            RuntimeError: If conversion or loading fails.
+        """
+        try:
+            from optimum.onnxruntime import ORTModelForFeatureExtraction
+            from transformers import AutoTokenizer
+        except ImportError as e:
+            raise ImportError(
+                "optimum[onnxruntime-gpu] is required for ONNX inference.\n"
+                "Install with:  uv pip install -e .[onnx]\n"
+                "Set use_onnx: false in search_config.json to use PyTorch."
+            ) from e
+
+        device = self._resolve_device()
+        provider = _resolve_provider(device)
+
+        # Auto-convert on first run
+        self.convert_if_needed(device)
+
+        # Load the optimized ONNX model
+        _log.info(
+            f"[ONNX] Loading {self.model_name!r} from {self._onnx_dir} via {provider}"
+        )
+        try:
+            ort_model = ORTModelForFeatureExtraction.from_pretrained(
+                str(self._onnx_dir),
+                provider=provider,
+            )
+            tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
+        except Exception as e:
+            raise RuntimeError(
+                f"[ONNX] Failed to load from {self._onnx_dir}: {e}\n"
+                f"Try re-converting: python tools/convert_onnx.py --model {self.model_name!r} --force"
+            ) from e
+
+        _log.info(f"[ONNX] Model loaded on {device} (provider={provider})")
+        return ort_model, tokenizer, device

--- a/embeddings/onnx_wrapper.py
+++ b/embeddings/onnx_wrapper.py
@@ -1,0 +1,132 @@
+"""SentenceTransformer-compatible wrapper for ONNX Runtime embedding models.
+
+Wraps ORTModelForFeatureExtraction with the same .encode() interface used by
+SentenceTransformer, so CodeEmbedder requires zero changes when ONNX is enabled.
+
+Pooling strategies:
+  "cls"  — take the [CLS] token output (position 0). Used by BGE models.
+  "mean" — average over all non-padding tokens using attention_mask. Used by GTE, Qwen3.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+
+if TYPE_CHECKING:
+    import numpy as np
+    import torch
+    from transformers import PreTrainedTokenizerBase
+
+
+_log = logging.getLogger(__name__)
+
+
+class ONNXEmbeddingModel:
+    """SentenceTransformer-compatible wrapper for ORTModelForFeatureExtraction.
+
+    Exposes encode() with the same signature as SentenceTransformer.encode() so
+    CodeEmbedder.embed_chunks() and embed_query() work without modification.
+
+    Args:
+        ort_model: Loaded ORTModelForFeatureExtraction instance.
+        tokenizer: AutoTokenizer for the model.
+        device: Device string ("cuda" or "cpu").
+        pooling: Pooling strategy — "cls" or "mean". Defaults to "cls".
+        model_name: Original HuggingFace model name (for logging).
+    """
+
+    def __init__(
+        self,
+        ort_model: Any,
+        tokenizer: PreTrainedTokenizerBase,
+        device: str,
+        pooling: str = "cls",
+        model_name: str = "",
+    ) -> None:
+        self.ort_model = ort_model
+        self.tokenizer = tokenizer
+        self.device = device
+        self.pooling = pooling
+        self.model_name = model_name
+
+        # Validate pooling strategy
+        if pooling not in ("cls", "mean"):
+            raise ValueError(
+                f"Unknown pooling strategy {pooling!r}. Expected 'cls' or 'mean'."
+            )
+
+        _log.info(
+            f"ONNXEmbeddingModel ready: model={model_name!r}, "
+            f"pooling={pooling!r}, device={device}"
+        )
+
+    def encode(
+        self,
+        sentences: list[str],
+        batch_size: int = 32,
+        show_progress_bar: bool = False,
+        convert_to_tensor: bool = False,
+        device: str | None = None,
+        prompt_name: str | None = None,
+        **kwargs: Any,
+    ) -> np.ndarray | torch.Tensor:
+        """Encode sentences into embeddings using ONNX Runtime.
+
+        Matches the SentenceTransformer.encode() signature so it can be used as a
+        drop-in replacement inside CodeEmbedder without any changes to calling code.
+
+        Args:
+            sentences: List of text strings to embed.
+            batch_size: Number of sentences per forward pass (ignored — all processed
+                at once since the ONNX model handles dynamic shapes).
+            show_progress_bar: Ignored (no progress bar for ONNX path).
+            convert_to_tensor: If True, return torch.Tensor; otherwise numpy array.
+            device: Override device for this call.
+            prompt_name: Ignored (ONNX models don't support built-in prompts;
+                sentences should be pre-formatted before calling encode()).
+            **kwargs: Additional kwargs silently ignored for compatibility.
+
+        Returns:
+            Embeddings as (N, dim) numpy array (float32) or torch.Tensor.
+        """
+        import torch
+        import torch.nn.functional as F  # noqa: N812
+
+        target_device = device or self.device
+
+        # Tokenize — let the tokenizer handle padding/truncation
+        encoded = self.tokenizer(
+            sentences,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        # Move to target device
+        if target_device == "cuda":
+            encoded = {k: v.cuda() for k, v in encoded.items()}
+
+        # Forward pass through ONNX Runtime
+        with torch.no_grad():
+            output = self.ort_model(**encoded)
+
+        last_hidden = output.last_hidden_state  # (N, seq_len, dim)
+
+        # Apply pooling
+        if self.pooling == "cls":
+            embeddings = last_hidden[:, 0, :]
+        else:  # mean
+            attention_mask = encoded["attention_mask"]  # (N, seq_len)
+            # Expand mask to match hidden dim and average over non-padding tokens
+            mask_expanded = attention_mask.unsqueeze(-1).float()
+            embeddings = (last_hidden * mask_expanded).sum(dim=1)
+            embeddings = embeddings / mask_expanded.sum(dim=1).clamp(min=1e-9)
+
+        # L2 normalize (standard for retrieval models)
+        embeddings = F.normalize(embeddings.float(), p=2, dim=1)
+
+        if convert_to_tensor:
+            return embeddings  # torch.Tensor on target_device
+        return embeddings.cpu().numpy()

--- a/embeddings/onnx_wrapper.py
+++ b/embeddings/onnx_wrapper.py
@@ -10,6 +10,7 @@ Pooling strategies:
 
 from __future__ import annotations
 
+import gc
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -50,6 +51,9 @@ class ONNXEmbeddingModel:
         self.device = device
         self.pooling = pooling
         self.model_name = model_name
+        # Set by ModelLoader._load_onnx() after measuring actual VRAM delta via pynvml.
+        # Used by CodeEmbedder._get_model_vram_gb() for dynamic batch-size calculation.
+        self._vram_gb: float = 0.0
 
         # Validate pooling strategy
         if pooling not in ("cls", "mean"):
@@ -61,6 +65,15 @@ class ONNXEmbeddingModel:
             f"ONNXEmbeddingModel ready: model={model_name!r}, "
             f"pooling={pooling!r}, device={device}"
         )
+
+    def get_sentence_embedding_dimension(self) -> int:
+        """Return embedding output dimension (SentenceTransformer compatibility)."""
+        return self.ort_model.config.hidden_size
+
+    @property
+    def max_seq_length(self) -> int:
+        """Return max sequence length (SentenceTransformer compatibility)."""
+        return getattr(self.ort_model.config, "max_position_embeddings", 512)
 
     def encode(
         self,
@@ -130,3 +143,35 @@ class ONNXEmbeddingModel:
         if convert_to_tensor:
             return embeddings  # torch.Tensor on target_device
         return embeddings.cpu().numpy()
+
+    def cleanup(self) -> None:
+        """Release ONNX Runtime CUDA session and free GPU memory.
+
+        ORT's CUDAExecutionProvider allocates CUDA memory outside PyTorch's
+        allocator. torch.cuda.empty_cache() cannot release it — the ORT session
+        must be explicitly deleted so its destructor frees the CUDA allocations.
+        """
+        import torch
+
+        try:
+            if self.ort_model is not None:
+                # Delete the ORT session — triggers CUDAExecutionProvider destructor
+                # which releases GPU memory allocated outside PyTorch.
+                del self.ort_model
+                self.ort_model = None  # type: ignore[assignment]
+            if self.tokenizer is not None:
+                del self.tokenizer
+                self.tokenizer = None  # type: ignore[assignment]
+
+            gc.collect()
+
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+                torch.cuda.empty_cache()
+
+            _log.info(
+                f"ONNXEmbeddingModel cleanup complete: model={self.model_name!r}, "
+                "ORT CUDA session released"
+            )
+        except Exception as e:
+            _log.warning(f"ONNXEmbeddingModel cleanup error: {e}")

--- a/mcp_server/tools/status_handlers.py
+++ b/mcp_server/tools/status_handlers.py
@@ -3,6 +3,7 @@
 Handlers for read-only status queries that don't modify state.
 """
 
+import contextlib
 import json
 import logging
 from typing import Any
@@ -197,28 +198,71 @@ async def handle_get_memory_status(arguments: dict[str, Any]) -> dict:
         "percent": mem.percent,
     }
 
-    # GPU memory
+    # GPU memory — use pynvml for real VRAM (ORT allocates outside PyTorch allocator)
     gpu_memory = {}
     if torch.cuda.is_available():
+        # Try pynvml for actual VRAM used by this process (includes ORT allocations)
+        nvml_available = False
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            nvml_available = True
+        except Exception:
+            pass
+
         for i in range(torch.cuda.device_count()):
-            allocated = torch.cuda.memory_allocated(i) / (1024**3)
-            reserved = torch.cuda.memory_reserved(i) / (1024**3)
+            torch_allocated = torch.cuda.memory_allocated(i) / (1024**3)
+            torch_reserved = torch.cuda.memory_reserved(i) / (1024**3)
             total_vram = torch.cuda.get_device_properties(i).total_memory / (1024**3)
 
-            gpu_memory[f"gpu_{i}"] = {
-                "allocated_gb": round(allocated, 2),
-                "reserved_gb": round(reserved, 2),
-                # Add GPU hardware details
+            # Real VRAM from nvml (includes ORT, reranker, all CUDA allocators)
+            if nvml_available:
+                try:
+                    handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+                    mem_info = pynvml.nvmlDeviceGetMemoryInfo(handle)
+                    real_used_gb = round(mem_info.used / (1024**3), 2)
+                    real_free_gb = round(mem_info.free / (1024**3), 2)
+                except Exception:
+                    real_used_gb = None
+                    real_free_gb = None
+            else:
+                real_used_gb = None
+                real_free_gb = None
+
+            entry: dict[str, Any] = {
+                "torch_allocated_gb": round(torch_allocated, 2),
+                "torch_reserved_gb": round(torch_reserved, 2),
                 "device_name": torch.cuda.get_device_name(i),
                 "device_id": i,
                 "total_vram_gb": round(total_vram, 1),
                 "compute_capability": ".".join(
                     map(str, torch.cuda.get_device_capability(i))
                 ),
-                "utilization_percent": (
-                    round((allocated / total_vram * 100), 1) if total_vram > 0 else 0
-                ),
             }
+            if real_used_gb is not None:
+                entry["used_gb"] = real_used_gb
+                entry["free_gb"] = real_free_gb
+                entry["utilization_percent"] = (
+                    round((real_used_gb / total_vram * 100), 1) if total_vram > 0 else 0
+                )
+                entry["ort_untracked_gb"] = round(
+                    max(0.0, real_used_gb - torch_allocated), 2
+                )
+            else:
+                # Fallback: torch only (may undercount ORT allocations)
+                entry["allocated_gb"] = round(torch_allocated, 2)
+                entry["reserved_gb"] = round(torch_reserved, 2)
+                entry["utilization_percent"] = (
+                    round((torch_allocated / total_vram * 100), 1)
+                    if total_vram > 0
+                    else 0
+                )
+            gpu_memory[f"gpu_{i}"] = entry
+
+        if nvml_available:
+            with contextlib.suppress(Exception):
+                pynvml.nvmlShutdown()
 
     # Index memory estimate
     index_memory = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "torch>=2.8.0,<2.9.0",  # 2.9.x breaks ModernBERT torch.compile (template conflict)
     "rich>=14.3.3",
     "sentence-transformers>=5.2.2",
-    "transformers>=5.0.0",  # Required for Qwen3-0.6B support
+    "transformers>=4.51.0,<4.58.0",  # >=4.51 for Qwen3; <4.58 required by optimum-onnx ONNX compatibility
     "sqlitedict>=2.1.0",
     "tree-sitter>=0.25.0",
     "tree-sitter-c>=0.24.1",
@@ -86,6 +86,13 @@ profile = [
     "snoop>=0.6.0",
     "py-heat>=0.0.6",
 ]
+onnx = [
+    "optimum[onnxruntime-gpu]>=1.25.0",
+]
+# NOTE: optimum[onnxruntime-gpu] caps transformers<4.58.0. This is why
+# transformers is pinned to >=4.51.0,<4.58.0 in the main dependencies.
+# Install: uv pip install -e .[onnx]
+# See tools/convert_onnx.py for standalone conversion usage.
 
 [project.urls]
 Homepage = "https://github.com/forkni/claude-context-local"

--- a/search/config.py
+++ b/search/config.py
@@ -34,6 +34,7 @@ MODEL_REGISTRY = {
         "description": "Default model, fast and efficient",
         "vram_gb": "4-8GB",
         "fallback_batch_size": 128,  # Used when dynamic sizing disabled
+        "onnx_pooling": "mean",  # Gemma uses mean pooling
     },
     "BAAI/bge-m3": {
         "dimension": 1024,
@@ -41,6 +42,7 @@ MODEL_REGISTRY = {
         "description": "Recommended upgrade, hybrid search support",
         "vram_gb": "1-1.5GB",  # Updated from "3-4GB" (actual measured: 1.07GB)
         "fallback_batch_size": 256,  # Used when dynamic sizing disabled
+        "onnx_pooling": "cls",  # BGE uses CLS pooling (confirmed by Optimum notebook)
     },
     "BAAI/bge-code-v1": {
         "dimension": 1536,
@@ -57,6 +59,7 @@ MODEL_REGISTRY = {
         "vram_gb": "2.3GB",
         "fallback_batch_size": 256,
         "vram_tier": "minimal",  # Usable on all GPUs
+        "onnx_pooling": "mean",  # Qwen3-Embedding uses mean pooling
         # Matryoshka Representation Learning (MRL) support
         "mrl_dimensions": [1024, 512, 256, 128, 64, 32],  # Supported MRL dimensions
         "truncate_dim": None,  # Optional: Set to reduce output dimension (e.g., 512)
@@ -83,6 +86,7 @@ MODEL_REGISTRY = {
         "vram_gb": "0.28GB",
         "fallback_batch_size": 256,
         "model_type": "code-optimized",
+        "onnx_pooling": "cls",  # GTE-ModernBERT uses CLS pooling
     },
 }
 
@@ -225,6 +229,11 @@ class PerformanceConfig:
         16  # Minimum batch size (lowered for fragmentation headroom)
     )
     dynamic_batch_max: int = 384  # Maximum batch size (safer for 8-16GB GPUs)
+
+    # ONNX Runtime inference (optional — requires uv pip install -e .[onnx])
+    use_onnx: bool = (
+        False  # When True, loads eligible models via ORTModelForFeatureExtraction
+    )
 
     # Auto-reindexing
     enable_auto_reindex: bool = True

--- a/search/config.py
+++ b/search/config.py
@@ -532,6 +532,7 @@ class SearchConfig:
                 "dynamic_batch_max": self.performance.dynamic_batch_max,
                 "enable_auto_reindex": self.performance.enable_auto_reindex,
                 "max_index_age_minutes": self.performance.max_index_age_minutes,
+                "use_onnx": self.performance.use_onnx,
             },
             "multi_hop": {
                 "enabled": self.multi_hop.enabled,
@@ -709,6 +710,7 @@ class SearchConfig:
                 max_index_age_minutes=performance_data.get(
                     "max_index_age_minutes", 5.0
                 ),
+                use_onnx=performance_data.get("use_onnx", False),
             )
 
             multi_hop = MultiHopConfig(
@@ -878,6 +880,7 @@ class SearchConfig:
                 dynamic_batch_max=data.get("dynamic_batch_max", 384),
                 enable_auto_reindex=data.get("enable_auto_reindex", True),
                 max_index_age_minutes=data.get("max_index_age_minutes", 5.0),
+                use_onnx=data.get("use_onnx", False),
             )
 
             multi_hop = MultiHopConfig(

--- a/search_config.json
+++ b/search_config.json
@@ -1,7 +1,7 @@
 {
   "embedding": {
-    "model_name": "BAAI/bge-code-v1",
-    "dimension": 1536,
+    "model_name": "Alibaba-NLP/gte-modernbert-base",
+    "dimension": 768,
     "batch_size": 128,
     "query_cache_size": 128,
     "enable_import_context": true,
@@ -32,14 +32,15 @@
     "enable_entity_tracking": true,
     "prefer_gpu": true,
     "vram_limit_fraction": 0.8,
-    "allow_ram_fallback": true,
+    "allow_ram_fallback": false,
     "enable_fp16": true,
     "prefer_bf16": true,
     "enable_dynamic_batch_size": true,
     "dynamic_batch_min": 16,
     "dynamic_batch_max": 64,
     "enable_auto_reindex": true,
-    "max_index_age_minutes": 30.0
+    "max_index_age_minutes": 30.0,
+    "use_onnx": true
   },
   "multi_hop": {
     "enabled": true,
@@ -50,8 +51,8 @@
   },
   "routing": {
     "multi_model_enabled": true,
-    "default_model": "qwen3",
-    "multi_model_pool": "full"
+    "default_model": "bge_m3",
+    "multi_model_pool": "lightweight-speed"
   },
   "intent": {
     "enabled": true,
@@ -63,7 +64,7 @@
   },
   "reranker": {
     "enabled": true,
-    "model_name": "jinaai/jina-reranker-v3",
+    "model_name": "Alibaba-NLP/gte-reranker-modernbert-base",
     "top_k_candidates": 50,
     "min_vram_gb": 6.0,
     "batch_size": 16

--- a/search_config.json
+++ b/search_config.json
@@ -1,7 +1,7 @@
 {
   "embedding": {
-    "model_name": "Qwen/Qwen3-Embedding-0.6B",
-    "dimension": 1024,
+    "model_name": "BAAI/bge-code-v1",
+    "dimension": 1536,
     "batch_size": 128,
     "query_cache_size": 128,
     "enable_import_context": true,
@@ -39,7 +39,8 @@
     "dynamic_batch_min": 16,
     "dynamic_batch_max": 64,
     "enable_auto_reindex": true,
-    "max_index_age_minutes": 30.0
+    "max_index_age_minutes": 30.0,
+    "use_onnx": false
   },
   "multi_hop": {
     "enabled": true,

--- a/search_config.json
+++ b/search_config.json
@@ -39,8 +39,7 @@
     "dynamic_batch_min": 16,
     "dynamic_batch_max": 64,
     "enable_auto_reindex": true,
-    "max_index_age_minutes": 30.0,
-    "use_onnx": false
+    "max_index_age_minutes": 30.0
   },
   "multi_hop": {
     "enabled": true,

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -22,6 +22,7 @@ supported_models = [m for m in MODEL_REGISTRY if "8B" not in m]
 
 
 @pytest.mark.parametrize("model_name", supported_models)
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_model_loading_and_embedding(
@@ -175,6 +176,7 @@ def test_prefixing_logic(mock_sentence_transformer, mock_model_loader_st):
     del MODEL_REGISTRY["test/query-prefix-model"]
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_query_cache_hits_and_misses(mock_sentence_transformer, mock_model_loader_st):
@@ -241,6 +243,7 @@ def test_query_cache_hits_and_misses(mock_sentence_transformer, mock_model_loade
     assert stats["cache_size"] == 2
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_query_cache_lru_eviction(mock_sentence_transformer, mock_model_loader_st):
@@ -584,6 +587,7 @@ def test_query_cache_with_task_instruction(
     assert stats["misses"] == 1
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_mrl_truncate_dim_support(mock_sentence_transformer, mock_model_loader_st):
@@ -631,6 +635,7 @@ def test_mrl_truncate_dim_support(mock_sentence_transformer, mock_model_loader_s
         )
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_instruction_mode_custom(mock_sentence_transformer, mock_model_loader_st):
@@ -674,6 +679,7 @@ def test_instruction_mode_custom(mock_sentence_transformer, mock_model_loader_st
     assert "prompt_name" not in encode_kwargs
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_instruction_mode_prompt_name(mock_sentence_transformer, mock_model_loader_st):
@@ -719,6 +725,7 @@ def test_instruction_mode_prompt_name(mock_sentence_transformer, mock_model_load
     MODEL_REGISTRY["Qwen/Qwen3-Embedding-0.6B"]["instruction_mode"] = "custom"
 
 
+@patch("embeddings.model_loader.ModelLoader._should_use_onnx", new=lambda self: False)
 @patch("embeddings.model_loader.SentenceTransformer")
 @patch("embeddings.embedder.SentenceTransformer")
 def test_instruction_mode_cache_keys(mock_sentence_transformer, mock_model_loader_st):

--- a/tests/unit/embeddings/test_model_loader.py
+++ b/tests/unit/embeddings/test_model_loader.py
@@ -41,13 +41,16 @@ class TestModelLoader:
     @pytest.fixture
     def model_loader(self, temp_cache_dir, cache_manager, model_config_basic):
         """Create a basic model loader for testing."""
-        return ModelLoader(
+        loader = ModelLoader(
             model_name="BAAI/bge-m3",
             cache_dir=str(temp_cache_dir),
             device="auto",
             cache_manager=cache_manager,
             model_config_getter=lambda: model_config_basic,
         )
+        # Keep tests isolated from live search_config.json (use_onnx=True)
+        loader._should_use_onnx = lambda: False
+        return loader
 
     def test_initialization(self, temp_cache_dir, cache_manager, model_config_basic):
         """Test model loader initialization."""

--- a/tests/unit/embeddings/test_onnx_loader.py
+++ b/tests/unit/embeddings/test_onnx_loader.py
@@ -1,0 +1,425 @@
+"""Tests for ONNXModelLoader and module-level helpers in embeddings/onnx_loader.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from embeddings.onnx_loader import (
+    ONNXModelLoader,
+    _is_converted,
+    _onnx_cache_dir,
+    _resolve_provider,
+)
+
+
+# ---------------------------------------------------------------------------
+# _onnx_cache_dir
+# ---------------------------------------------------------------------------
+
+
+class TestOnnxCacheDir:
+    def test_slash_replaced_with_double_dash(self):
+        result = _onnx_cache_dir("BAAI/bge-m3")
+        assert result.name == "BAAI--bge-m3"
+
+    def test_no_slash_unchanged(self):
+        result = _onnx_cache_dir("some-model")
+        assert result.name == "some-model"
+
+    def test_multiple_slashes(self):
+        result = _onnx_cache_dir("org/sub/model")
+        assert result.name == "org--sub--model"
+
+    def test_default_parent_path(self):
+        result = _onnx_cache_dir("BAAI/bge-m3")
+        expected = Path.home() / ".cache" / "huggingface" / "onnx" / "BAAI--bge-m3"
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# _is_converted
+# ---------------------------------------------------------------------------
+
+
+class TestIsConverted:
+    def test_true_with_optimized_model(self, tmp_path):
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert _is_converted(tmp_path) is True
+
+    def test_true_with_base_model_fallback(self, tmp_path):
+        """model.onnx is accepted as fallback when model_optimized.onnx is absent."""
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model.onnx").write_bytes(b"")
+        assert _is_converted(tmp_path) is True
+
+    def test_false_missing_meta(self, tmp_path):
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert _is_converted(tmp_path) is False
+
+    def test_false_missing_model_file(self, tmp_path):
+        (tmp_path / "convert_meta.json").write_text("{}")
+        assert _is_converted(tmp_path) is False
+
+    def test_false_empty_dir(self, tmp_path):
+        assert _is_converted(tmp_path) is False
+
+    def test_false_nonexistent_dir(self, tmp_path):
+        assert _is_converted(tmp_path / "does_not_exist") is False
+
+
+# ---------------------------------------------------------------------------
+# _resolve_provider
+# ---------------------------------------------------------------------------
+
+
+class TestResolveProvider:
+    def test_cuda_returns_cuda_provider(self):
+        assert _resolve_provider("cuda") == "CUDAExecutionProvider"
+
+    def test_cpu_returns_cpu_provider(self):
+        assert _resolve_provider("cpu") == "CPUExecutionProvider"
+
+    def test_unknown_device_returns_cpu_provider(self):
+        assert _resolve_provider("tpu") == "CPUExecutionProvider"
+        assert _resolve_provider("mps") == "CPUExecutionProvider"
+
+
+# ---------------------------------------------------------------------------
+# _convert_model
+# ---------------------------------------------------------------------------
+
+
+class TestConvertModel:
+    """Tests for the internal _convert_model() function."""
+
+    def _make_optimum_mocks(self, tmp_path, create_optimized=True):
+        """Build mock optimum.onnxruntime module and optionally create the model file."""
+        mock_ort_model = MagicMock()
+        mock_optimizer = MagicMock()
+        mock_opt_config_cls = MagicMock()
+        mock_opt_config = MagicMock()
+        mock_opt_config_cls.return_value = mock_opt_config
+        mock_optimizer.optimize = MagicMock(
+            side_effect=lambda **kw: (
+                (tmp_path / "model_optimized.onnx").write_bytes(b"")
+                if create_optimized
+                else None
+            )
+        )
+
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = (
+            mock_ort_model
+        )
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        mock_ort.AutoOptimizationConfig.O4 = mock_opt_config_cls
+        return mock_ort
+
+    def test_import_error_when_optimum_missing(self, tmp_path):
+        with patch.dict("sys.modules", {"optimum.onnxruntime": None}):
+            from embeddings.onnx_loader import _convert_model
+
+            with pytest.raises(ImportError, match="optimum"):
+                _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+    def test_export_failure_raises_runtime_error(self, tmp_path):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.side_effect = (
+            RuntimeError("export boom")
+        )
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            with pytest.raises(RuntimeError, match="Export failed"):
+                _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+    def test_optimization_failure_raises_runtime_error(self, tmp_path):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.side_effect = RuntimeError("opt boom")
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            with pytest.raises(RuntimeError, match="Optimization failed"):
+                _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+    def test_success_writes_meta_json(self, tmp_path):
+        mock_ort = self._make_optimum_mocks(tmp_path, create_optimized=True)
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+        meta_path = tmp_path / "convert_meta.json"
+        assert meta_path.is_file()
+        meta = json.loads(meta_path.read_text())
+        assert meta["source_model"] == "BAAI/bge-m3"
+        assert meta["optimization_level"] == "O4"
+        assert meta["gemm_gelu_fusion"] is True
+        assert meta["device"] == "cpu"
+        assert meta["quality_validated"] is False
+
+    def test_success_creates_directory(self, tmp_path):
+        new_dir = tmp_path / "sub" / "cache"
+        mock_ort = self._make_optimum_mocks(new_dir, create_optimized=True)
+        # Recreate side_effect to write into new_dir
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize = MagicMock(
+            side_effect=lambda **kw: (new_dir / "model_optimized.onnx").write_bytes(b"")
+        )
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            _convert_model("test-model", new_dir, "cpu")
+
+        assert new_dir.is_dir()
+
+    def test_model_file_fallback_to_model_onnx(self, tmp_path):
+        """When model_optimized.onnx absent but model.onnx present, meta records model.onnx."""
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+
+        def _fake_optimize(**kw):
+            (tmp_path / "model.onnx").write_bytes(b"")  # only base model created
+
+        mock_optimizer.optimize.side_effect = _fake_optimize
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+        meta = json.loads((tmp_path / "convert_meta.json").read_text())
+        assert meta["model_file"] == "model.onnx"
+
+    def test_model_file_optimized_recorded_in_meta(self, tmp_path):
+        mock_ort = self._make_optimum_mocks(tmp_path, create_optimized=True)
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            from embeddings.onnx_loader import _convert_model
+
+            _convert_model("BAAI/bge-m3", tmp_path, "cpu")
+
+        meta = json.loads((tmp_path / "convert_meta.json").read_text())
+        assert meta["model_file"] == "model_optimized.onnx"
+
+
+# ---------------------------------------------------------------------------
+# ONNXModelLoader — init & properties
+# ---------------------------------------------------------------------------
+
+
+class TestONNXModelLoaderInit:
+    def test_stores_attributes(self, tmp_path):
+        loader = ONNXModelLoader("BAAI/bge-m3", cache_dir=str(tmp_path), device="cpu")
+        assert loader.model_name == "BAAI/bge-m3"
+        assert loader.cache_dir == str(tmp_path)
+        assert loader._raw_device == "cpu"
+
+    def test_default_onnx_dir_is_derived_from_model_name(self):
+        loader = ONNXModelLoader("BAAI/bge-m3")
+        expected = Path.home() / ".cache" / "huggingface" / "onnx" / "BAAI--bge-m3"
+        assert loader._onnx_dir == expected
+
+    def test_custom_onnx_cache_dir_overrides_default(self, tmp_path):
+        custom = tmp_path / "custom_onnx"
+        loader = ONNXModelLoader("BAAI/bge-m3", onnx_cache_dir=custom)
+        assert loader._onnx_dir == custom
+
+    def test_onnx_dir_property_returns_onnx_dir(self, tmp_path):
+        custom = tmp_path / "onnx"
+        loader = ONNXModelLoader("BAAI/bge-m3", onnx_cache_dir=custom)
+        assert loader.onnx_dir == custom
+
+
+# ---------------------------------------------------------------------------
+# ONNXModelLoader — _resolve_device
+# ---------------------------------------------------------------------------
+
+
+class TestONNXModelLoaderResolveDevice:
+    def test_explicit_cpu(self):
+        loader = ONNXModelLoader("m", device="cpu")
+        assert loader._resolve_device() == "cpu"
+
+    def test_explicit_cuda(self):
+        loader = ONNXModelLoader("m", device="cuda")
+        assert loader._resolve_device() == "cuda"
+
+    def test_auto_with_cuda_available(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        loader = ONNXModelLoader("m", device="auto")
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            assert loader._resolve_device() == "cuda"
+
+    def test_auto_without_cuda(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        loader = ONNXModelLoader("m", device="auto")
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            assert loader._resolve_device() == "cpu"
+
+    def test_auto_no_torch_defaults_to_cpu(self):
+        loader = ONNXModelLoader("m", device="auto")
+        # Simulate missing torch by setting sys.modules entry to None (causes ImportError)
+        with patch.dict("sys.modules", {"torch": None}):
+            result = loader._resolve_device()
+        assert result == "cpu"
+
+
+# ---------------------------------------------------------------------------
+# ONNXModelLoader — is_converted & convert_if_needed
+# ---------------------------------------------------------------------------
+
+
+class TestONNXModelLoaderIsConverted:
+    def test_delegates_to_module_function(self, tmp_path):
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path)
+        # Nothing in tmp_path → not converted
+        assert loader.is_converted() is False
+        # Add required files
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert loader.is_converted() is True
+
+
+class TestONNXModelLoaderConvertIfNeeded:
+    def test_converts_when_not_cached(self, tmp_path):
+        loader = ONNXModelLoader("BAAI/bge-m3", onnx_cache_dir=tmp_path)
+        with (
+            patch("embeddings.onnx_loader._convert_model") as mock_convert,
+            patch("embeddings.onnx_loader._is_converted", return_value=False),
+        ):
+            loader.convert_if_needed("cpu")
+            mock_convert.assert_called_once_with("BAAI/bge-m3", tmp_path, "cpu")
+
+    def test_skips_when_already_cached(self, tmp_path):
+        loader = ONNXModelLoader("BAAI/bge-m3", onnx_cache_dir=tmp_path)
+        with (
+            patch("embeddings.onnx_loader._convert_model") as mock_convert,
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+        ):
+            loader.convert_if_needed("cpu")
+            mock_convert.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ONNXModelLoader — load()
+# ---------------------------------------------------------------------------
+
+
+class TestONNXModelLoaderLoad:
+    def _setup_load_mocks(self, tmp_path):
+        """Return (mock_ort_model, mock_tokenizer, mock_ort_module, mock_transformers)."""
+        mock_ort_model = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = (
+            mock_ort_model
+        )
+        mock_tf = MagicMock()
+        mock_tf.AutoTokenizer.from_pretrained.return_value = mock_tokenizer
+        return mock_ort_model, mock_tokenizer, mock_ort, mock_tf
+
+    def test_import_error_if_optimum_missing(self, tmp_path):
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+        with (
+            patch.dict("sys.modules", {"optimum.onnxruntime": None}),
+            pytest.raises(ImportError, match="optimum"),
+        ):
+            loader.load()
+
+    def test_skips_conversion_when_cached(self, tmp_path):
+        mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(
+            tmp_path
+        )
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+            patch("embeddings.onnx_loader._convert_model") as mock_convert,
+        ):
+            loader.load()
+            mock_convert.assert_not_called()
+
+    def test_auto_converts_when_not_cached(self, tmp_path):
+        mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(
+            tmp_path
+        )
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=False),
+            patch("embeddings.onnx_loader._convert_model") as mock_convert,
+        ):
+            loader.load()
+            mock_convert.assert_called_once_with("m", tmp_path, "cpu")
+
+    def test_returns_ort_model_tokenizer_device(self, tmp_path):
+        mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(
+            tmp_path
+        )
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+        ):
+            result = loader.load()
+        assert len(result) == 3
+        ort_model, tokenizer, device = result
+        assert ort_model is mock_ort_model
+        assert tokenizer is mock_tokenizer
+        assert device == "cpu"
+
+    def test_cuda_device_passes_cuda_provider(self, tmp_path):
+        mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(
+            tmp_path
+        )
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cuda")
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+        ):
+            loader.load()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.assert_called_once_with(
+            str(tmp_path), provider="CUDAExecutionProvider"
+        )
+
+    def test_runtime_error_on_model_load_failure(self, tmp_path):
+        mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(
+            tmp_path
+        )
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.side_effect = Exception(
+            "load boom"
+        )
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+            pytest.raises(RuntimeError, match="Failed to load"),
+        ):
+            loader.load()

--- a/tests/unit/embeddings/test_onnx_loader.py
+++ b/tests/unit/embeddings/test_onnx_loader.py
@@ -402,9 +402,10 @@ class TestONNXModelLoaderLoad:
             patch("embeddings.onnx_loader._is_converted", return_value=True),
         ):
             loader.load()
-        mock_ort.ORTModelForFeatureExtraction.from_pretrained.assert_called_once_with(
-            str(tmp_path), provider="CUDAExecutionProvider"
-        )
+        call_kwargs = mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args
+        assert call_kwargs.args == (str(tmp_path),)
+        assert call_kwargs.kwargs["provider"] == "CUDAExecutionProvider"
+        assert "session_options" in call_kwargs.kwargs
 
     def test_runtime_error_on_model_load_failure(self, tmp_path):
         mock_ort_model, mock_tokenizer, mock_ort, mock_tf = self._setup_load_mocks(

--- a/tests/unit/embeddings/test_onnx_model_loader_integration.py
+++ b/tests/unit/embeddings/test_onnx_model_loader_integration.py
@@ -1,0 +1,328 @@
+"""Tests for the ONNX integration methods in embeddings/model_loader.py.
+
+Covers _should_use_onnx(), _load_onnx(), and the ONNX fast path in load().
+Follows the same patterns as tests/unit/embeddings/test_model_loader.py.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from embeddings.model_cache import ModelCacheManager
+from embeddings.model_loader import ModelLoader
+
+
+class TestShouldUseOnnx:
+    """Tests for ModelLoader._should_use_onnx()."""
+
+    @pytest.fixture
+    def temp_cache_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def model_config_basic(self):
+        return {"model_type": "bert", "dimension": 768}
+
+    @pytest.fixture
+    def model_loader(self, temp_cache_dir, model_config_basic):
+        cache_manager = ModelCacheManager(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            model_config_getter=lambda: model_config_basic,
+        )
+        return ModelLoader(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            device="auto",
+            cache_manager=cache_manager,
+            model_config_getter=lambda: model_config_basic,
+        )
+
+    def _make_config(self, use_onnx: bool) -> MagicMock:
+        config = MagicMock()
+        config.performance.use_onnx = use_onnx
+        return config
+
+    def test_returns_true_when_enabled_and_eligible(self, model_loader):
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            return_value=self._make_config(True),
+        ):
+            assert model_loader._should_use_onnx() is True
+
+    def test_returns_false_when_disabled(self, model_loader):
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            return_value=self._make_config(False),
+        ):
+            assert model_loader._should_use_onnx() is False
+
+    def test_returns_false_when_trust_remote_code(self, temp_cache_dir):
+        trust_config = {"trust_remote_code": True, "dimension": 768}
+        cache_manager = ModelCacheManager(
+            model_name="nomic-ai/CodeRankEmbed",
+            cache_dir=str(temp_cache_dir),
+            model_config_getter=lambda: trust_config,
+        )
+        loader = ModelLoader(
+            model_name="nomic-ai/CodeRankEmbed",
+            cache_dir=str(temp_cache_dir),
+            device="auto",
+            cache_manager=cache_manager,
+            model_config_getter=lambda: trust_config,
+        )
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            return_value=self._make_config(True),
+        ):
+            assert loader._should_use_onnx() is False
+
+    def test_returns_false_when_config_raises_exception(self, model_loader):
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            side_effect=RuntimeError("service locator down"),
+        ):
+            assert model_loader._should_use_onnx() is False
+
+    def test_returns_false_when_config_is_none(self, model_loader):
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            return_value=None,
+        ):
+            assert model_loader._should_use_onnx() is False
+
+    def test_returns_false_when_no_use_onnx_attr(self, model_loader):
+        """Performance config without use_onnx attribute defaults to False."""
+        config = MagicMock()
+        # Remove use_onnx from the mock spec so getattr fallback kicks in
+        del config.performance.use_onnx
+        with patch(
+            "mcp_server.utils.config_helpers.get_config_via_service_locator",
+            return_value=config,
+        ):
+            assert model_loader._should_use_onnx() is False
+
+
+class TestLoadOnnx:
+    """Tests for ModelLoader._load_onnx()."""
+
+    @pytest.fixture
+    def temp_cache_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    def _make_loader(self, temp_cache_dir, model_config):
+        cache_manager = ModelCacheManager(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            model_config_getter=lambda: model_config,
+        )
+        return ModelLoader(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            device="cpu",
+            cache_manager=cache_manager,
+            model_config_getter=lambda: model_config,
+        )
+
+    def test_creates_loader_with_correct_args(self, temp_cache_dir):
+        model_config = {"dimension": 768, "onnx_pooling": "cls"}
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_ort = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (mock_ort, mock_tokenizer, "cpu")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ) as mock_loader_cls,
+            patch("embeddings.onnx_wrapper.ONNXEmbeddingModel"),
+        ):
+            loader._load_onnx()
+
+        mock_loader_cls.assert_called_once_with(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            device="cpu",
+        )
+
+    def test_creates_wrapper_with_cls_pooling_from_registry(self, temp_cache_dir):
+        model_config = {"dimension": 768, "onnx_pooling": "cls"}
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_ort = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (mock_ort, mock_tokenizer, "cpu")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ),
+            patch("embeddings.onnx_wrapper.ONNXEmbeddingModel") as mock_wrapper_cls,
+        ):
+            loader._load_onnx()
+
+        call_kwargs = mock_wrapper_cls.call_args[1]
+        assert call_kwargs["pooling"] == "cls"
+
+    def test_creates_wrapper_with_mean_pooling_from_registry(self, temp_cache_dir):
+        model_config = {"dimension": 768, "onnx_pooling": "mean"}
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_ort = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (mock_ort, mock_tokenizer, "cpu")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ),
+            patch("embeddings.onnx_wrapper.ONNXEmbeddingModel") as mock_wrapper_cls,
+        ):
+            loader._load_onnx()
+
+        call_kwargs = mock_wrapper_cls.call_args[1]
+        assert call_kwargs["pooling"] == "mean"
+
+    def test_defaults_pooling_to_cls_when_not_in_config(self, temp_cache_dir):
+        model_config = {"dimension": 768}  # no onnx_pooling key
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (MagicMock(), MagicMock(), "cpu")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ),
+            patch("embeddings.onnx_wrapper.ONNXEmbeddingModel") as mock_wrapper_cls,
+        ):
+            loader._load_onnx()
+
+        call_kwargs = mock_wrapper_cls.call_args[1]
+        assert call_kwargs["pooling"] == "cls"
+
+    def test_returns_wrapper_and_device(self, temp_cache_dir):
+        model_config = {"dimension": 768}
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_wrapper = MagicMock()
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (MagicMock(), MagicMock(), "cuda")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ),
+            patch(
+                "embeddings.onnx_wrapper.ONNXEmbeddingModel", return_value=mock_wrapper
+            ),
+        ):
+            result_model, result_device = loader._load_onnx()
+
+        assert result_model is mock_wrapper
+        assert result_device == "cuda"
+
+    def test_passes_ort_model_and_tokenizer_to_wrapper(self, temp_cache_dir):
+        model_config = {"dimension": 768}
+        loader = self._make_loader(temp_cache_dir, model_config)
+
+        mock_ort = MagicMock()
+        mock_tokenizer = MagicMock()
+        mock_ort_loader = MagicMock()
+        mock_ort_loader.load.return_value = (mock_ort, mock_tokenizer, "cpu")
+
+        with (
+            patch(
+                "embeddings.onnx_loader.ONNXModelLoader", return_value=mock_ort_loader
+            ),
+            patch("embeddings.onnx_wrapper.ONNXEmbeddingModel") as mock_wrapper_cls,
+        ):
+            loader._load_onnx()
+
+        call_kwargs = mock_wrapper_cls.call_args[1]
+        assert call_kwargs["ort_model"] is mock_ort
+        assert call_kwargs["tokenizer"] is mock_tokenizer
+
+
+class TestModelLoaderLoadOnnxFastPath:
+    """Tests verifying the ONNX fast path in ModelLoader.load()."""
+
+    @pytest.fixture
+    def temp_cache_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield Path(tmpdir)
+
+    @pytest.fixture
+    def model_loader(self, temp_cache_dir):
+        model_config = {"dimension": 768}
+        cache_manager = ModelCacheManager(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            model_config_getter=lambda: model_config,
+        )
+        return ModelLoader(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(temp_cache_dir),
+            device="cpu",
+            cache_manager=cache_manager,
+            model_config_getter=lambda: model_config,
+        )
+
+    def test_onnx_path_taken_when_eligible(self, model_loader):
+        mock_model = MagicMock()
+        with (
+            patch.object(model_loader, "_should_use_onnx", return_value=True),
+            patch.object(
+                model_loader, "_load_onnx", return_value=(mock_model, "cpu")
+            ) as mock_load_onnx,
+            patch("embeddings.model_loader.SentenceTransformer") as mock_st,
+        ):
+            result_model, result_device = model_loader.load()
+
+        mock_load_onnx.assert_called_once()
+        mock_st.assert_not_called()
+        assert result_model is mock_model
+        assert result_device == "cpu"
+
+    def test_pytorch_path_taken_when_onnx_not_eligible(self, model_loader):
+        mock_st_model = MagicMock()
+        mock_st_model.device = "cpu"
+
+        with (
+            patch.object(model_loader, "_should_use_onnx", return_value=False),
+            patch(
+                "embeddings.model_loader.SentenceTransformer",
+                return_value=mock_st_model,
+            ) as mock_st,
+            patch.object(
+                model_loader._cache_manager, "validate_cache", return_value=(True, "ok")
+            ),
+            patch.object(model_loader, "resolve_device", return_value="cpu"),
+            patch.object(model_loader, "get_torch_dtype", return_value=None),
+        ):
+            result_model, result_device = model_loader.load()
+
+        mock_st.assert_called_once()
+
+    def test_onnx_path_bypasses_cache_validation(self, model_loader):
+        mock_model = MagicMock()
+        with (
+            patch.object(model_loader, "_should_use_onnx", return_value=True),
+            patch.object(model_loader, "_load_onnx", return_value=(mock_model, "cpu")),
+            patch.object(
+                model_loader._cache_manager, "validate_cache"
+            ) as mock_validate,
+        ):
+            model_loader.load()
+
+        mock_validate.assert_not_called()

--- a/tests/unit/embeddings/test_onnx_wrapper.py
+++ b/tests/unit/embeddings/test_onnx_wrapper.py
@@ -1,0 +1,256 @@
+"""Tests for ONNXEmbeddingModel in embeddings/onnx_wrapper.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from embeddings.onnx_wrapper import ONNXEmbeddingModel
+
+
+def _make_ort_model(batch_size: int = 1, seq_len: int = 8, dim: int = 16) -> MagicMock:
+    """Return a mock ORT model whose output has .last_hidden_state of shape (B, S, D)."""
+    hidden = torch.randn(batch_size, seq_len, dim)
+    output = MagicMock()
+    output.last_hidden_state = hidden
+    ort_model = MagicMock()
+    ort_model.return_value = output
+    return ort_model
+
+
+def _make_tokenizer(batch_size: int = 1, seq_len: int = 8) -> MagicMock:
+    """Return a mock tokenizer whose call returns input_ids and attention_mask tensors."""
+    tokenizer = MagicMock()
+    tokenizer.return_value = {
+        "input_ids": torch.ones(batch_size, seq_len, dtype=torch.long),
+        "attention_mask": torch.ones(batch_size, seq_len, dtype=torch.long),
+    }
+    return tokenizer
+
+
+class TestONNXEmbeddingModelInit:
+    def test_init_cls_pooling_stores_attributes(self):
+        ort_model = MagicMock()
+        tokenizer = MagicMock()
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls", "BAAI/bge-m3")
+        assert model.ort_model is ort_model
+        assert model.tokenizer is tokenizer
+        assert model.device == "cpu"
+        assert model.pooling == "cls"
+        assert model.model_name == "BAAI/bge-m3"
+
+    def test_init_mean_pooling_succeeds(self):
+        model = ONNXEmbeddingModel(MagicMock(), MagicMock(), "cuda", "mean")
+        assert model.pooling == "mean"
+
+    def test_init_invalid_pooling_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown pooling strategy"):
+            ONNXEmbeddingModel(MagicMock(), MagicMock(), "cpu", "max")
+
+    def test_init_default_pooling_is_cls(self):
+        model = ONNXEmbeddingModel(MagicMock(), MagicMock(), "cpu")
+        assert model.pooling == "cls"
+
+    def test_init_default_model_name_is_empty(self):
+        model = ONNXEmbeddingModel(MagicMock(), MagicMock(), "cpu")
+        assert model.model_name == ""
+
+
+class TestONNXEmbeddingModelEncodeCLS:
+    @pytest.fixture
+    def model_cls(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=8, dim=16)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=8)
+        return ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+
+    def test_encode_cls_returns_numpy_array(self, model_cls):
+        result = model_cls.encode(["hello world"])
+        import numpy as np
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == (1, 16)
+
+    def test_encode_cls_calls_tokenizer_with_correct_args(self, model_cls):
+        model_cls.encode(["sentence one"])
+        model_cls.tokenizer.assert_called_once_with(
+            ["sentence one"],
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+    def test_encode_cls_calls_ort_model_with_encoded_inputs(self, model_cls):
+        model_cls.encode(["test"])
+        assert model_cls.ort_model.called
+
+    def test_encode_cls_multibatch_output_shape(self):
+        ort_model = _make_ort_model(batch_size=3, seq_len=10, dim=32)
+        tokenizer = _make_tokenizer(batch_size=3, seq_len=10)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        result = model.encode(["a", "b", "c"])
+        assert result.shape == (3, 32)
+
+    def test_encode_cls_selects_position_zero(self):
+        # Create hidden states where position 0 is all-ones and rest are zeros
+        hidden = torch.zeros(1, 8, 16)
+        hidden[:, 0, :] = 1.0  # only CLS token has signal
+        output = MagicMock()
+        output.last_hidden_state = hidden
+        ort_model = MagicMock(return_value=output)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=8)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        result = model.encode(["test"], convert_to_tensor=True)
+        # CLS token is all-ones, so after L2 norm it should be all-positive
+        assert result.shape == (1, 16)
+        assert (result > 0).all()
+
+    def test_encode_cls_applies_l2_normalization(self):
+        hidden = torch.ones(2, 4, 8) * 3.0  # unnormalized large values
+        output = MagicMock()
+        output.last_hidden_state = hidden
+        ort_model = MagicMock(return_value=output)
+        tokenizer = _make_tokenizer(batch_size=2, seq_len=4)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        result = model.encode(["a", "b"], convert_to_tensor=True)
+        norms = result.norm(dim=1)
+        assert torch.allclose(norms, torch.ones(2), atol=1e-5)
+
+
+class TestONNXEmbeddingModelEncodeMean:
+    def test_encode_mean_uses_all_tokens(self):
+        # Make hidden states distinct per position to distinguish mean from CLS
+        hidden = torch.zeros(1, 4, 8)
+        hidden[:, 0, :] = 10.0  # CLS
+        hidden[:, 1, :] = 2.0  # token 1
+        hidden[:, 2, :] = 2.0  # token 2
+        hidden[:, 3, :] = 0.0  # padding
+        output = MagicMock()
+        output.last_hidden_state = hidden
+
+        ort_model = MagicMock(return_value=output)
+        tokenizer = MagicMock()
+        # Mask: only first 3 tokens are real
+        tokenizer.return_value = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1, 0]], dtype=torch.long),
+        }
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "mean")
+        result = model.encode(["test"], convert_to_tensor=True)
+        # Mean of [10, 2, 2] / 3 = 4.666... for each dim before norm
+        assert result.shape == (1, 8)
+        assert (result > 0).all()  # all values positive (uniform hidden states)
+
+    def test_encode_mean_handles_near_zero_mask_sum(self):
+        # Edge case: mask with very few tokens to stress the clamp
+        hidden = torch.ones(1, 4, 8)
+        output = MagicMock()
+        output.last_hidden_state = hidden
+        ort_model = MagicMock(return_value=output)
+        tokenizer = MagicMock()
+        tokenizer.return_value = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 0, 0, 0]], dtype=torch.long),
+        }
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "mean")
+        # Should not raise (no div-by-zero)
+        result = model.encode(["test"], convert_to_tensor=True)
+        assert not torch.isnan(result).any()
+
+    def test_encode_mean_applies_l2_normalization(self):
+        hidden = torch.ones(1, 4, 16) * 5.0
+        output = MagicMock()
+        output.last_hidden_state = hidden
+        ort_model = MagicMock(return_value=output)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=4)
+        # Override dim to match hidden
+        tokenizer.return_value = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long),
+            "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        }
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "mean")
+        result = model.encode(["test"], convert_to_tensor=True)
+        assert torch.allclose(result.norm(dim=1), torch.ones(1), atol=1e-5)
+
+
+class TestONNXEmbeddingModelEncodeReturnType:
+    @pytest.fixture
+    def model(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=6, dim=8)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=6)
+        return ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+
+    def test_returns_numpy_by_default(self, model):
+        import numpy as np
+
+        result = model.encode(["test"])
+        assert isinstance(result, np.ndarray)
+
+    def test_returns_numpy_when_convert_to_tensor_false(self, model):
+        import numpy as np
+
+        result = model.encode(["test"], convert_to_tensor=False)
+        assert isinstance(result, np.ndarray)
+
+    def test_returns_tensor_when_convert_to_tensor_true(self, model):
+        result = model.encode(["test"], convert_to_tensor=True)
+        assert isinstance(result, torch.Tensor)
+
+
+class TestONNXEmbeddingModelEncodeDevice:
+    def test_encode_cpu_does_not_move_to_cuda(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=4, dim=8)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=4)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        # Should not raise even without CUDA
+        model.encode(["test"])
+        # Tokenizer was called and returned cpu tensors — no .cuda() should be needed
+        encoded = tokenizer.return_value
+        assert encoded["input_ids"].device.type == "cpu"
+
+    def test_encode_uses_instance_device_by_default(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=4, dim=8)
+        mock_tokenizer = MagicMock()
+        tokens = {
+            "input_ids": torch.ones(1, 4, dtype=torch.long),
+            "attention_mask": torch.ones(1, 4, dtype=torch.long),
+        }
+        mock_tokenizer.return_value = tokens
+        model = ONNXEmbeddingModel(ort_model, mock_tokenizer, "cpu", "cls")
+        model.encode(["test"])
+        # Verify tokenizer was called (device routing used instance device "cpu")
+        mock_tokenizer.assert_called_once()
+
+    def test_encode_extra_kwargs_silently_ignored(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=4, dim=8)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=4)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        # Should not raise TypeError for unrecognized kwargs
+        model.encode(
+            ["test"],
+            batch_size=64,
+            show_progress_bar=True,
+            normalize_embeddings=True,
+        )
+
+    def test_encode_prompt_name_ignored(self):
+        ort_model = _make_ort_model(batch_size=1, seq_len=4, dim=8)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=4)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        model.encode(["test"], prompt_name="query")
+        # Tokenizer should NOT have received prompt_name
+        call_kwargs = tokenizer.call_args[1]
+        assert "prompt_name" not in call_kwargs
+
+    def test_encode_empty_sentence_list_does_not_raise(self):
+        ort_model = _make_ort_model(batch_size=0, seq_len=4, dim=8)
+        tokenizer = MagicMock()
+        tokenizer.return_value = {
+            "input_ids": torch.zeros(0, 4, dtype=torch.long),
+            "attention_mask": torch.zeros(0, 4, dtype=torch.long),
+        }
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        # Should complete without raising
+        result = model.encode([], convert_to_tensor=True)
+        assert result.shape[0] == 0

--- a/tests/unit/tools/test_convert_onnx.py
+++ b/tests/unit/tools/test_convert_onnx.py
@@ -53,11 +53,11 @@ class TestConvertOnnxIsConverted:
         (tmp_path / "model_optimized.onnx").write_bytes(b"")
         assert convert_onnx._is_converted(tmp_path) is True
 
-    def test_false_with_only_base_model(self, tmp_path):
-        """CLI version requires model_optimized.onnx specifically — model.onnx alone is not enough."""
+    def test_true_with_only_base_model(self, tmp_path):
+        """model.onnx (unoptimized fallback) is also accepted as a valid conversion."""
         (tmp_path / "convert_meta.json").write_text("{}")
         (tmp_path / "model.onnx").write_bytes(b"")
-        assert convert_onnx._is_converted(tmp_path) is False
+        assert convert_onnx._is_converted(tmp_path) is True
 
     def test_false_missing_meta(self, tmp_path):
         (tmp_path / "model_optimized.onnx").write_bytes(b"")
@@ -177,6 +177,33 @@ class TestConvert:
         assert result == tmp_path
         meta = json.loads((tmp_path / "convert_meta.json").read_text())
         assert meta["model_file"] == "model.onnx"
+
+    def test_unsupported_arch_falls_back_to_unoptimized(self, tmp_path):
+        """When ORTOptimizer reports unsupported architecture, save unoptimized model.onnx."""
+        mock_ort = MagicMock()
+        mock_ort_model = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = (
+            mock_ort_model
+        )
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.side_effect = RuntimeError(
+            "ONNX Runtime doesn't support the graph optimization of qwen3 yet."
+        )
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+
+        def _save_pretrained(save_dir, **kw):
+            (Path(save_dir) / "model.onnx").write_bytes(b"")
+
+        mock_ort_model.save_pretrained.side_effect = _save_pretrained
+
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            result = convert_onnx.convert("BAAI/bge-m3", device="cpu", output=tmp_path)
+
+        assert result == tmp_path
+        assert (tmp_path / "model.onnx").is_file()
+        meta = json.loads((tmp_path / "convert_meta.json").read_text())
+        assert meta["optimization_level"] == "none"
+        assert meta["gemm_gelu_fusion"] is False
 
     def test_no_model_file_after_optimization_raises(self, tmp_path):
         mock_ort = MagicMock()

--- a/tests/unit/tools/test_convert_onnx.py
+++ b/tests/unit/tools/test_convert_onnx.py
@@ -1,0 +1,492 @@
+"""Tests for tools/convert_onnx.py — standalone ONNX conversion script."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper: importable convert_onnx module
+# ---------------------------------------------------------------------------
+
+# The script lives in tools/, which is not a package. Add it to sys.path once.
+_TOOLS_DIR = str(Path(__file__).parent.parent.parent.parent / "tools")
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+import convert_onnx  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _onnx_cache_dir
+# ---------------------------------------------------------------------------
+
+
+class TestConvertOnnxCacheDir:
+    def test_default_base_uses_home_cache(self):
+        result = convert_onnx._onnx_cache_dir("BAAI/bge-m3")
+        expected = Path.home() / ".cache" / "huggingface" / "onnx" / "BAAI--bge-m3"
+        assert result == expected
+
+    def test_custom_base(self, tmp_path):
+        result = convert_onnx._onnx_cache_dir("BAAI/bge-m3", base=tmp_path)
+        assert result == tmp_path / "BAAI--bge-m3"
+
+    def test_slash_replaced_with_double_dash(self, tmp_path):
+        result = convert_onnx._onnx_cache_dir("org/my/model", base=tmp_path)
+        assert result.name == "org--my--model"
+
+
+# ---------------------------------------------------------------------------
+# _is_converted (CLI version — stricter: requires model_optimized.onnx only)
+# ---------------------------------------------------------------------------
+
+
+class TestConvertOnnxIsConverted:
+    def test_true_with_optimized_model(self, tmp_path):
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert convert_onnx._is_converted(tmp_path) is True
+
+    def test_false_with_only_base_model(self, tmp_path):
+        """CLI version requires model_optimized.onnx specifically — model.onnx alone is not enough."""
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model.onnx").write_bytes(b"")
+        assert convert_onnx._is_converted(tmp_path) is False
+
+    def test_false_missing_meta(self, tmp_path):
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert convert_onnx._is_converted(tmp_path) is False
+
+    def test_false_empty_dir(self, tmp_path):
+        assert convert_onnx._is_converted(tmp_path) is False
+
+
+# ---------------------------------------------------------------------------
+# convert()
+# ---------------------------------------------------------------------------
+
+
+class TestConvert:
+    def _make_optimum_mocks(self, tmp_path, create_optimized=True):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+
+        def _fake_optimize(**kw):
+            if create_optimized:
+                (tmp_path / "model_optimized.onnx").write_bytes(b"")
+
+        mock_optimizer.optimize.side_effect = _fake_optimize
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        return mock_ort
+
+    def test_ineligible_model_raises_value_error(self, tmp_path):
+        with pytest.raises(ValueError, match="not eligible"):
+            convert_onnx.convert("nomic-ai/CodeRankEmbed", output=tmp_path)
+
+    def test_import_error_when_optimum_missing(self, tmp_path):
+        with (
+            patch.dict("sys.modules", {"optimum.onnxruntime": None}),
+            pytest.raises(ImportError, match="optimum"),
+        ):
+            convert_onnx.convert("BAAI/bge-m3", output=tmp_path)
+
+    def test_already_converted_skips_conversion(self, tmp_path, capsys):
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        # Should return early without touching optimum
+        result = convert_onnx.convert("BAAI/bge-m3", output=tmp_path)
+        assert result == tmp_path
+
+    def test_export_failure_raises_runtime_error(self, tmp_path):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.side_effect = (
+            RuntimeError("export boom")
+        )
+        with (
+            patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}),
+            pytest.raises(RuntimeError, match="export failed"),
+        ):
+            convert_onnx.convert("BAAI/bge-m3", output=tmp_path)
+
+    def test_optimization_failure_raises_runtime_error(self, tmp_path):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.side_effect = RuntimeError("opt boom")
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with (
+            patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}),
+            pytest.raises(RuntimeError, match="optimization failed"),
+        ):
+            convert_onnx.convert("BAAI/bge-m3", output=tmp_path)
+
+    def test_auto_device_detects_cuda(self, tmp_path):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_ort = self._make_optimum_mocks(tmp_path)
+        with patch.dict(
+            "sys.modules", {"optimum.onnxruntime": mock_ort, "torch": mock_torch}
+        ):
+            convert_onnx.convert("BAAI/bge-m3", device=None, output=tmp_path)
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.assert_called_once()
+        call_kwargs = mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args[1]
+        assert call_kwargs["provider"] == "CUDAExecutionProvider"
+
+    def test_auto_device_detects_cpu(self, tmp_path):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_ort = self._make_optimum_mocks(tmp_path)
+        with patch.dict(
+            "sys.modules", {"optimum.onnxruntime": mock_ort, "torch": mock_torch}
+        ):
+            convert_onnx.convert("BAAI/bge-m3", device=None, output=tmp_path)
+        call_kwargs = mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args[1]
+        assert call_kwargs["provider"] == "CPUExecutionProvider"
+
+    def test_success_writes_meta_json(self, tmp_path):
+        mock_ort = self._make_optimum_mocks(tmp_path, create_optimized=True)
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            convert_onnx.convert("BAAI/bge-m3", device="cpu", output=tmp_path)
+        meta_path = tmp_path / "convert_meta.json"
+        assert meta_path.is_file()
+        meta = json.loads(meta_path.read_text())
+        assert meta["source_model"] == "BAAI/bge-m3"
+        assert meta["device"] == "cpu"
+        assert meta["quality_validated"] is False
+
+    def test_model_file_fallback_to_model_onnx(self, tmp_path):
+        """When optimization produces model.onnx but not model_optimized.onnx, log warning and use fallback."""
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+
+        def _fake_optimize(**kw):
+            (tmp_path / "model.onnx").write_bytes(b"")
+
+        mock_optimizer.optimize.side_effect = _fake_optimize
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            result = convert_onnx.convert("BAAI/bge-m3", device="cpu", output=tmp_path)
+        assert result == tmp_path
+        meta = json.loads((tmp_path / "convert_meta.json").read_text())
+        assert meta["model_file"] == "model.onnx"
+
+    def test_no_model_file_after_optimization_raises(self, tmp_path):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        mock_optimizer = MagicMock()
+        mock_optimizer.optimize.return_value = None  # creates nothing
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with (
+            patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}),
+            pytest.raises(RuntimeError, match="No ONNX model file found"),
+        ):
+            convert_onnx.convert("BAAI/bge-m3", device="cpu", output=tmp_path)
+
+    def test_custom_output_dir_used(self, tmp_path):
+        custom = tmp_path / "my_output"
+        mock_ort = self._make_optimum_mocks(custom, create_optimized=True)
+        # Recreate optimizer to write into custom dir
+        mock_optimizer = MagicMock()
+
+        def _fake_optimize(**kw):
+            custom.mkdir(parents=True, exist_ok=True)
+            (custom / "model_optimized.onnx").write_bytes(b"")
+
+        mock_optimizer.optimize.side_effect = _fake_optimize
+        mock_ort.ORTOptimizer.from_pretrained.return_value = mock_optimizer
+        with patch.dict("sys.modules", {"optimum.onnxruntime": mock_ort}):
+            result = convert_onnx.convert("BAAI/bge-m3", device="cpu", output=custom)
+        assert result == custom
+
+
+# ---------------------------------------------------------------------------
+# validate()
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def _make_validate_mocks(self, max_diff: float):
+        """Return mocks for SentenceTransformer and ORT producing controlled embedding diff."""
+        import torch
+
+        # Create normalized embeddings with a known difference
+        pt_embs = torch.tensor([[1.0, 0.0]])
+        ort_hidden = torch.tensor([[[1.0 - max_diff, 0.0, 0.0]]])  # shape (1, 1, 3)
+
+        mock_pt_model = MagicMock()
+        mock_pt_model.encode.return_value = pt_embs
+
+        mock_ort = MagicMock()
+        mock_out = MagicMock()
+        mock_out.last_hidden_state = ort_hidden
+        mock_ort.return_value = mock_out
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.ones(1, 1, dtype=torch.long),
+            "attention_mask": torch.ones(1, 1, dtype=torch.long),
+        }
+
+        mock_st_cls = MagicMock(return_value=mock_pt_model)
+        mock_ort_cls = MagicMock()
+        mock_ort_cls.from_pretrained.return_value = mock_ort
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        return mock_st_cls, mock_ort_cls, mock_tokenizer_cls
+
+    def test_passes_when_diff_below_threshold(self, tmp_path):
+        """When max cosine diff < 0.001, validate() returns True."""
+        (tmp_path / "convert_meta.json").write_text(json.dumps({}))
+        import torch
+
+        pt_embs = torch.nn.functional.normalize(torch.ones(10, 8), p=2, dim=1)
+        ort_embs = pt_embs.clone()  # identical → diff = 0
+
+        mock_pt_model = MagicMock()
+        mock_pt_model.encode.return_value = pt_embs
+
+        mock_ort_model = MagicMock()
+        mock_out = MagicMock()
+        # last_hidden_state[:, 0, :] == ort_embs (shape N, 1, 8)
+        mock_out.last_hidden_state = ort_embs.unsqueeze(1)
+        mock_ort_model.return_value = mock_out
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.ones(10, 4, dtype=torch.long),
+            "attention_mask": torch.ones(10, 4, dtype=torch.long),
+        }
+
+        mock_st_cls = MagicMock(return_value=mock_pt_model)
+        mock_ort_cls = MagicMock()
+        mock_ort_cls.from_pretrained.return_value = mock_ort_model
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sentence_transformers": MagicMock(SentenceTransformer=mock_st_cls),
+                "optimum.onnxruntime": MagicMock(
+                    ORTModelForFeatureExtraction=mock_ort_cls
+                ),
+                "transformers": MagicMock(AutoTokenizer=mock_tokenizer_cls),
+            },
+        ):
+            result = convert_onnx.validate("BAAI/bge-m3", tmp_path, device="cpu")
+
+        assert result is True
+
+    def test_fails_when_diff_above_threshold(self, tmp_path):
+        """When max cosine diff > 0.001, validate() returns False."""
+        (tmp_path / "convert_meta.json").write_text(json.dumps({}))
+        import torch
+
+        pt_embs = torch.nn.functional.normalize(torch.ones(10, 8), p=2, dim=1)
+        # Make ONNX embeddings very different
+        ort_embs_hidden = torch.zeros(10, 1, 8)  # all zeros → large diff after norm
+
+        mock_pt_model = MagicMock()
+        mock_pt_model.encode.return_value = pt_embs
+
+        mock_ort_model = MagicMock()
+        mock_out = MagicMock()
+        mock_out.last_hidden_state = ort_embs_hidden
+        mock_ort_model.return_value = mock_out
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.ones(10, 4, dtype=torch.long),
+            "attention_mask": torch.ones(10, 4, dtype=torch.long),
+        }
+
+        mock_st_cls = MagicMock(return_value=mock_pt_model)
+        mock_ort_cls = MagicMock()
+        mock_ort_cls.from_pretrained.return_value = mock_ort_model
+        mock_tokenizer_cls = MagicMock()
+        mock_tokenizer_cls.from_pretrained.return_value = mock_tokenizer
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sentence_transformers": MagicMock(SentenceTransformer=mock_st_cls),
+                "optimum.onnxruntime": MagicMock(
+                    ORTModelForFeatureExtraction=mock_ort_cls
+                ),
+                "transformers": MagicMock(AutoTokenizer=mock_tokenizer_cls),
+            },
+        ):
+            result = convert_onnx.validate("BAAI/bge-m3", tmp_path, device="cpu")
+
+        assert result is False
+
+    def test_updates_meta_on_pass(self, tmp_path):
+        (tmp_path / "convert_meta.json").write_text(
+            json.dumps({"quality_validated": False})
+        )
+        import torch
+
+        embs = torch.nn.functional.normalize(torch.ones(10, 8), p=2, dim=1)
+
+        mock_pt_model = MagicMock()
+        mock_pt_model.encode.return_value = embs
+        mock_ort_model = MagicMock()
+        mock_out = MagicMock()
+        mock_out.last_hidden_state = embs.unsqueeze(1)
+        mock_ort_model.return_value = mock_out
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {
+            "input_ids": torch.ones(10, 4, dtype=torch.long),
+            "attention_mask": torch.ones(10, 4, dtype=torch.long),
+        }
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "sentence_transformers": MagicMock(
+                    SentenceTransformer=MagicMock(return_value=mock_pt_model)
+                ),
+                "optimum.onnxruntime": MagicMock(
+                    ORTModelForFeatureExtraction=MagicMock(
+                        from_pretrained=MagicMock(return_value=mock_ort_model)
+                    )
+                ),
+                "transformers": MagicMock(
+                    AutoTokenizer=MagicMock(
+                        from_pretrained=MagicMock(return_value=mock_tokenizer)
+                    )
+                ),
+            },
+        ):
+            convert_onnx.validate("BAAI/bge-m3", tmp_path)
+
+        meta = json.loads((tmp_path / "convert_meta.json").read_text())
+        assert meta["quality_validated"] is True
+        assert "quality_max_diff" in meta
+
+    def test_missing_sentence_transformers_returns_false(self, tmp_path):
+        with patch.dict("sys.modules", {"sentence_transformers": None}):
+            result = convert_onnx.validate("BAAI/bge-m3", tmp_path)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# list_models()
+# ---------------------------------------------------------------------------
+
+
+class TestListModels:
+    def test_prints_ok_and_skip_markers(self, capsys):
+        mock_registry = {
+            "BAAI/bge-m3": {"description": "Dense embedding"},
+            "nomic-ai/CodeRankEmbed": {"trust_remote_code": True},
+        }
+        with patch.dict(
+            "sys.modules",
+            {
+                "search": MagicMock(),
+                "search.config": MagicMock(MODEL_REGISTRY=mock_registry),
+            },
+        ):
+            convert_onnx.list_models()
+
+        captured = capsys.readouterr()
+        assert "OK" in captured.out or "SKIP" in captured.out
+        assert "BAAI/bge-m3" in captured.out
+        assert "nomic-ai/CodeRankEmbed" in captured.out
+
+    def test_import_error_calls_sys_exit(self):
+        with (
+            patch.dict("sys.modules", {"search": None, "search.config": None}),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            convert_onnx.list_models()
+        assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# main() — argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_list_flag_calls_list_models_and_returns(self):
+        with (
+            patch("sys.argv", ["convert_onnx", "--list"]),
+            patch("convert_onnx.list_models") as mock_list,
+            patch("convert_onnx.convert") as mock_convert,
+        ):
+            convert_onnx.main()
+        mock_list.assert_called_once()
+        mock_convert.assert_not_called()
+
+    def test_model_required_without_list_exits(self):
+        with patch("sys.argv", ["convert_onnx"]), pytest.raises(SystemExit):
+            convert_onnx.main()
+
+    def test_force_deletes_existing_cache(self, tmp_path):
+        (tmp_path / "convert_meta.json").write_text("{}")
+        (tmp_path / "model_optimized.onnx").write_bytes(b"")
+        assert tmp_path.exists()
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "convert_onnx",
+                    "--model",
+                    "BAAI/bge-m3",
+                    "--force",
+                    "--output",
+                    str(tmp_path),
+                ],
+            ),
+            patch("convert_onnx.convert", return_value=tmp_path),
+            patch("shutil.rmtree") as mock_rmtree,
+        ):
+            convert_onnx.main()
+
+        mock_rmtree.assert_called_once_with(tmp_path)
+
+    def test_validate_flag_calls_validate_after_convert(self, tmp_path):
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "convert_onnx",
+                    "--model",
+                    "BAAI/bge-m3",
+                    "--validate",
+                    "--output",
+                    str(tmp_path),
+                ],
+            ),
+            patch("convert_onnx.convert", return_value=tmp_path),
+            patch("convert_onnx.validate", return_value=True) as mock_validate,
+            patch("convert_onnx._cuda_available", return_value=False),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            convert_onnx.main()
+        mock_validate.assert_called_once()
+        assert exc_info.value.code == 0
+
+    def test_convert_error_exits_with_code_1(self, tmp_path):
+        with (
+            patch(
+                "sys.argv",
+                ["convert_onnx", "--model", "BAAI/bge-m3", "--output", str(tmp_path)],
+            ),
+            patch("convert_onnx.convert", side_effect=ValueError("ineligible")),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            convert_onnx.main()
+        assert exc_info.value.code == 1

--- a/tools/convert_onnx.py
+++ b/tools/convert_onnx.py
@@ -37,7 +37,9 @@ _ONNX_INELIGIBLE = {
     "jinaai/jina-reranker-v3",  # Listwise, custom model.rerank() API
     "Qwen/Qwen3-Reranker-0.6B",  # Generative causal LM, wrong paradigm for ONNX
     "Qwen/Qwen3-Reranker-4B",
+    "Qwen/Qwen3-Embedding-0.6B",  # ORT requires position_ids not provided by tokenizer
     "BAAI/bge-code-v1",  # 2B params, GPU-bound — marginal ONNX gain
+    "google/embeddinggemma-300m",  # Gemma3 ONNX trace breaks (TracerWarnings → wrong embeddings)
 }
 
 _OPTIMIZE_LEVELS = ("O1", "O2", "O3", "O4")
@@ -57,8 +59,10 @@ def _onnx_cache_dir(model_name: str, base: Path | None = None) -> Path:
 def _is_converted(onnx_dir: Path) -> bool:
     """True if a valid converted model already exists at onnx_dir."""
     meta = onnx_dir / "convert_meta.json"
-    model_file = onnx_dir / "model_optimized.onnx"
-    return meta.is_file() and model_file.is_file()
+    return meta.is_file() and (
+        (onnx_dir / "model_optimized.onnx").is_file()
+        or (onnx_dir / "model.onnx").is_file()
+    )
 
 
 def list_models() -> None:
@@ -177,7 +181,10 @@ def convert(
     # Step 2: Optimize with O4 + GEMM GELU fusion
     # GEMM GELU fusion is more accurate than gelu_approximation (max diff 0.0004 vs 0.0011)
     # per the Faster_Embeddings_with_Optimum.ipynb benchmark.
+    # For architectures not yet supported by ORTOptimizer (e.g. gemma3, qwen3), we fall back
+    # to saving the unoptimized ONNX export so the model is still usable for inference.
     _log.info(f"Step 2/2: Applying {optimize} optimization + GEMM GELU fusion...")
+    _optimized = True
     try:
         optimizer = ORTOptimizer.from_pretrained(ort_model)
 
@@ -191,7 +198,25 @@ def convert(
             optimization_config=optimization_config,
         )
     except Exception as e:
-        raise RuntimeError(f"ONNX optimization failed: {e}") from e
+        _unsupported = "not available yet" in str(
+            e
+        ) or "doesn't support the graph optimization" in str(e)
+        if _unsupported:
+            _log.warning(
+                "ORTOptimizer does not support this architecture — saving unoptimized model."
+            )
+            _log.warning(f"  Reason: {e}")
+            ort_model.save_pretrained(str(onnx_dir))
+            # save_pretrained() saves model+config but not the tokenizer — save it explicitly
+            try:
+                from transformers import AutoTokenizer
+
+                AutoTokenizer.from_pretrained(model_name).save_pretrained(str(onnx_dir))
+            except Exception as tok_err:
+                _log.warning(f"Could not save tokenizer to ONNX dir: {tok_err}")
+            _optimized = False
+        else:
+            raise RuntimeError(f"ONNX optimization failed: {e}") from e
 
     # Verify the optimized model file exists
     model_file = onnx_dir / "model_optimized.onnx"
@@ -216,8 +241,8 @@ def convert(
 
     meta = {
         "source_model": model_name,
-        "optimization_level": optimize,
-        "gemm_gelu_fusion": True,
+        "optimization_level": optimize if _optimized else "none",
+        "gemm_gelu_fusion": _optimized,
         "device": device,
         "provider": provider,
         "converted_at": datetime.now(UTC).isoformat(),
@@ -300,7 +325,12 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
 
     # Load ONNX model
     _log.info("Loading ONNX model...")
-    tokenizer = AutoTokenizer.from_pretrained(str(onnx_dir))
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(str(onnx_dir))
+    except Exception:
+        # Unoptimized fallback models may not have tokenizer saved in onnx_dir
+        _log.info("Tokenizer not in ONNX dir — loading from original model name...")
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
     ort_model = ORTModelForFeatureExtraction.from_pretrained(
         str(onnx_dir), provider=provider
     )
@@ -429,7 +459,9 @@ Examples:
         sys.exit(1)
 
     if args.validate:
-        device = args.device or ("cuda" if _cuda_available() else "cpu")
+        # Default to CPU for quality validation — avoids ORT CUDA provider compatibility
+        # issues on some systems. Use --device cuda to force CUDA validation explicitly.
+        device = args.device or "cpu"
         ok = validate(args.model, onnx_dir, device=device)
         sys.exit(0 if ok else 1)
 

--- a/tools/convert_onnx.py
+++ b/tools/convert_onnx.py
@@ -1,0 +1,426 @@
+"""Standalone ONNX conversion script for claude-context-local embedding models.
+
+Exports a HuggingFace embedding model to ONNX with O4 graph optimization and
+GEMM GELU fusion (best accuracy/speed tradeoff per the Optimum benchmark).
+
+Usage:
+    python tools/convert_onnx.py --model BAAI/bge-m3 --validate
+    python tools/convert_onnx.py --model Alibaba-NLP/gte-modernbert-base --device cpu
+    python tools/convert_onnx.py --list
+    python tools/convert_onnx.py --model BAAI/bge-m3 --optimize O2 --output /custom/path
+
+Install dependency first:
+    uv pip install -e .[onnx]
+    # or: pip install optimum[onnxruntime-gpu]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+_log = logging.getLogger(__name__)
+
+# Models ineligible for ONNX export (custom code or generative arch)
+_ONNX_INELIGIBLE = {
+    "nomic-ai/CodeRankEmbed",  # NomicBERT requires trust_remote_code — no ORT config
+    "jinaai/jina-reranker-v3",  # Listwise, custom model.rerank() API
+    "Qwen/Qwen3-Reranker-0.6B",  # Generative causal LM, wrong paradigm for ONNX
+    "Qwen/Qwen3-Reranker-4B",
+    "BAAI/bge-code-v1",  # 2B params, GPU-bound — marginal ONNX gain
+}
+
+_OPTIMIZE_LEVELS = ("O1", "O2", "O3", "O4")
+
+
+def _onnx_cache_dir(model_name: str, base: Path | None = None) -> Path:
+    """Return the canonical ONNX output directory for a model.
+
+    Convention: ~/.cache/huggingface/onnx/<org>--<name>/
+    e.g. BAAI/bge-m3  →  ~/.cache/huggingface/onnx/BAAI--bge-m3/
+    """
+    sanitized = model_name.replace("/", "--")
+    root = base or (Path.home() / ".cache" / "huggingface" / "onnx")
+    return root / sanitized
+
+
+def _is_converted(onnx_dir: Path) -> bool:
+    """True if a valid converted model already exists at onnx_dir."""
+    meta = onnx_dir / "convert_meta.json"
+    model_file = onnx_dir / "model_optimized.onnx"
+    return meta.is_file() and model_file.is_file()
+
+
+def list_models() -> None:
+    """Print eligible models from MODEL_REGISTRY."""
+    try:
+        from search.config import MODEL_REGISTRY
+    except ImportError:
+        _log.error("Cannot import MODEL_REGISTRY. Run from the project root.")
+        sys.exit(1)
+
+    print("\nONNX-eligible models from MODEL_REGISTRY:")
+    print("-" * 60)
+    for name, cfg in MODEL_REGISTRY.items():
+        if name in _ONNX_INELIGIBLE or cfg.get("trust_remote_code"):
+            status = "SKIP"
+            reason = (
+                "trust_remote_code" if cfg.get("trust_remote_code") else "ineligible"
+            )
+        else:
+            status = "OK  "
+            reason = cfg.get("description", "")
+        print(f"  [{status}]  {name}")
+        if reason:
+            print(f"          {reason}")
+    print()
+
+
+def _resolve_provider(device: str) -> str:
+    """Map device string to ONNX Runtime execution provider."""
+    if device == "cuda":
+        return "CUDAExecutionProvider"
+    return "CPUExecutionProvider"
+
+
+def convert(
+    model_name: str,
+    optimize: str = "O4",
+    device: str | None = None,
+    output: Path | None = None,
+) -> Path:
+    """Export and optimize a model to ONNX.
+
+    Args:
+        model_name: HuggingFace model name (e.g. "BAAI/bge-m3").
+        optimize: Optimization level — O1 / O2 / O3 / O4.
+        device: "cuda" or "cpu". Auto-detected if None.
+        output: Custom output directory. Defaults to ~/.cache/huggingface/onnx/<model>/.
+
+    Returns:
+        Path to the directory containing the optimized ONNX model.
+
+    Raises:
+        ImportError: If optimum[onnxruntime-gpu] is not installed.
+        ValueError: If model is ONNX-ineligible.
+        RuntimeError: If conversion or optimization fails.
+    """
+    if model_name in _ONNX_INELIGIBLE:
+        raise ValueError(
+            f"{model_name!r} is not eligible for ONNX export.\n"
+            "Reason: custom architecture, generative model, or too large for meaningful gain.\n"
+            "Run --list to see eligible models."
+        )
+
+    # Lazy import — only required when converting
+    try:
+        from optimum.onnxruntime import (
+            AutoOptimizationConfig,
+            ORTModelForFeatureExtraction,
+            ORTOptimizer,
+        )
+    except ImportError as e:
+        raise ImportError(
+            "optimum[onnxruntime-gpu] is not installed.\n"
+            "Install with:  uv pip install -e .[onnx]\n"
+            "           or: pip install optimum[onnxruntime-gpu]"
+        ) from e
+
+    # Resolve device
+    if device is None:
+        try:
+            import torch
+
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            device = "cpu"
+
+    provider = _resolve_provider(device)
+    onnx_dir = output or _onnx_cache_dir(model_name)
+
+    _log.info(f"Model:     {model_name}")
+    _log.info(f"Optimize:  {optimize}")
+    _log.info(f"Device:    {device} ({provider})")
+    _log.info(f"Output:    {onnx_dir}")
+
+    if _is_converted(onnx_dir):
+        _log.info(
+            "ONNX model already exists — skipping conversion (use --force to re-convert)."
+        )
+        return onnx_dir
+
+    onnx_dir.mkdir(parents=True, exist_ok=True)
+
+    # Step 1: Export model to ONNX (in-memory export, not saved yet)
+    _log.info("Step 1/2: Exporting to ONNX...")
+    try:
+        ort_model = ORTModelForFeatureExtraction.from_pretrained(
+            model_name,
+            export=True,
+            provider=provider,
+        )
+    except Exception as e:
+        raise RuntimeError(f"ONNX export failed for {model_name!r}: {e}") from e
+
+    # Step 2: Optimize with O4 + GEMM GELU fusion
+    # GEMM GELU fusion is more accurate than gelu_approximation (max diff 0.0004 vs 0.0011)
+    # per the Faster_Embeddings_with_Optimum.ipynb benchmark.
+    _log.info(f"Step 2/2: Applying {optimize} optimization + GEMM GELU fusion...")
+    try:
+        optimizer = ORTOptimizer.from_pretrained(ort_model)
+
+        opt_config_cls = getattr(AutoOptimizationConfig, optimize)
+        optimization_config = opt_config_cls()
+        optimization_config.enable_gelu_approximation = False
+        optimization_config.enable_gemm_fast_gelu_fusion = True
+
+        optimizer.optimize(
+            save_dir=str(onnx_dir),
+            optimization_config=optimization_config,
+        )
+    except Exception as e:
+        raise RuntimeError(f"ONNX optimization failed: {e}") from e
+
+    # Verify the optimized model file exists
+    model_file = onnx_dir / "model_optimized.onnx"
+    if not model_file.is_file():
+        # Some optimum versions save as model.onnx (unoptimized fallback)
+        fallback = onnx_dir / "model.onnx"
+        if fallback.is_file():
+            _log.warning("Optimized model not found; falling back to model.onnx")
+            model_file = fallback
+        else:
+            raise RuntimeError(
+                f"No ONNX model file found in {onnx_dir}. Conversion may have failed."
+            )
+
+    # Write conversion metadata
+    try:
+        import optimum
+
+        optimum_version = optimum.__version__
+    except Exception:
+        optimum_version = "unknown"
+
+    meta = {
+        "source_model": model_name,
+        "optimization_level": optimize,
+        "gemm_gelu_fusion": True,
+        "device": device,
+        "provider": provider,
+        "converted_at": datetime.now(UTC).isoformat(),
+        "optimum_version": optimum_version,
+        "model_file": model_file.name,
+        "quality_validated": False,
+    }
+    (onnx_dir / "convert_meta.json").write_text(json.dumps(meta, indent=2))
+
+    _log.info(f"Conversion complete → {onnx_dir}")
+    return onnx_dir
+
+
+def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
+    """Quality gate: compare PyTorch vs ONNX embeddings.
+
+    Encodes 10 code-like sentences with both backends. Passes if max cosine diff < 0.001
+    (threshold from the Optimum notebook benchmark: GEMM GELU max diff was 0.0004).
+
+    Args:
+        model_name: Original HuggingFace model name for PyTorch reference.
+        onnx_dir: Directory containing the optimized ONNX model.
+        device: Device for inference ("cuda" or "cpu").
+
+    Returns:
+        True if quality gate passes, False otherwise.
+    """
+    _log.info("Running quality validation (PyTorch vs ONNX)...")
+
+    test_sentences = [
+        "def embed_query(self, query: str) -> np.ndarray:",
+        "class ModelLoader: handles loading and device management",
+        "import torch\nfrom sentence_transformers import SentenceTransformer",
+        "ONNX Runtime provides hardware-accelerated inference",
+        "batch_embeddings = self.model.encode(batch_contents, convert_to_tensor=True)",
+        "Search results are ranked candidates, not definitive answers",
+        "def calculate_optimal_batch_size(embedding_dim, min_batch, max_batch):",
+        "raise VRAMExhaustedError('VRAM exhausted, close other GPU apps')",
+        "from optimum.onnxruntime import ORTModelForFeatureExtraction",
+        "hybrid_score = bm25_weight * bm25_score + dense_weight * dense_score",
+    ]
+
+    try:
+        import torch
+        import torch.nn.functional as F  # noqa: N812
+        from sentence_transformers import SentenceTransformer
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        _log.error(f"Missing dependency for validation: {e}")
+        return False
+
+    try:
+        from optimum.onnxruntime import ORTModelForFeatureExtraction
+    except ImportError as e:
+        _log.error(f"optimum not available: {e}")
+        return False
+
+    provider = _resolve_provider(device)
+
+    # Load PyTorch reference model
+    _log.info("Loading PyTorch reference model...")
+    pt_model = SentenceTransformer(model_name, device=device)
+    pt_embeddings = pt_model.encode(
+        test_sentences, convert_to_tensor=True, device=device
+    )
+    pt_embeddings = F.normalize(pt_embeddings.float(), p=2, dim=1)
+
+    # Load ONNX model
+    _log.info("Loading ONNX model...")
+    tokenizer = AutoTokenizer.from_pretrained(str(onnx_dir))
+    ort_model = ORTModelForFeatureExtraction.from_pretrained(
+        str(onnx_dir), provider=provider
+    )
+
+    # Encode with ONNX
+    encoded = tokenizer(
+        test_sentences, padding=True, truncation=True, return_tensors="pt"
+    )
+    with torch.no_grad():
+        ort_out = ort_model(**encoded)
+    # CLS pooling (position 0 of last_hidden_state)
+    onnx_embeddings = ort_out.last_hidden_state[:, 0, :]
+    onnx_embeddings = F.normalize(onnx_embeddings.float(), p=2, dim=1)
+
+    # Compute diffs
+    diffs = (pt_embeddings.cpu() - onnx_embeddings.cpu()).abs()
+    max_diff = float(diffs.max())
+    mean_diff = float(diffs.mean())
+    threshold = 0.001
+
+    _log.info(f"Max cosine diff:  {max_diff:.6f}  (threshold: {threshold})")
+    _log.info(f"Mean cosine diff: {mean_diff:.6f}")
+
+    if max_diff <= threshold:
+        _log.info("Quality gate PASSED ✓")
+        # Update metadata
+        meta_path = onnx_dir / "convert_meta.json"
+        if meta_path.is_file():
+            meta = json.loads(meta_path.read_text())
+            meta["quality_validated"] = True
+            meta["quality_max_diff"] = max_diff
+            meta["quality_mean_diff"] = mean_diff
+            meta_path.write_text(json.dumps(meta, indent=2))
+        return True
+    else:
+        _log.error(
+            f"Quality gate FAILED ✗ — max diff {max_diff:.6f} exceeds threshold {threshold}"
+        )
+        return False
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export and optimize embedding models to ONNX for claude-context-local.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python tools/convert_onnx.py --list
+  python tools/convert_onnx.py --model BAAI/bge-m3 --validate
+  python tools/convert_onnx.py --model Alibaba-NLP/gte-modernbert-base --optimize O4
+  python tools/convert_onnx.py --model BAAI/bge-m3 --device cpu --output /tmp/bge-m3-onnx
+        """,
+    )
+    parser.add_argument("--model", "-m", help="HuggingFace model name to convert")
+    parser.add_argument(
+        "--optimize",
+        "-o",
+        default="O4",
+        choices=_OPTIMIZE_LEVELS,
+        help="Optimization level (default: O4 — maximum fusions)",
+    )
+    parser.add_argument(
+        "--device",
+        "-d",
+        choices=("cuda", "cpu"),
+        default=None,
+        help="Inference device (default: auto-detect)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Custom output directory (default: ~/.cache/huggingface/onnx/<model>/)",
+    )
+    parser.add_argument(
+        "--validate",
+        "-v",
+        action="store_true",
+        help="Run quality gate after conversion (PyTorch vs ONNX max diff < 0.001)",
+    )
+    parser.add_argument(
+        "--list",
+        "-l",
+        action="store_true",
+        help="List ONNX-eligible models from MODEL_REGISTRY and exit",
+    )
+    parser.add_argument(
+        "--force",
+        "-f",
+        action="store_true",
+        help="Re-convert even if ONNX model already exists",
+    )
+
+    args = parser.parse_args()
+
+    if args.list:
+        list_models()
+        return
+
+    if not args.model:
+        parser.error("--model is required unless --list is specified")
+
+    if args.force:
+        onnx_dir = args.output or _onnx_cache_dir(args.model)
+        if onnx_dir.exists():
+            import shutil
+
+            _log.info(f"--force: removing existing ONNX cache at {onnx_dir}")
+            shutil.rmtree(onnx_dir)
+
+    try:
+        onnx_dir = convert(
+            model_name=args.model,
+            optimize=args.optimize,
+            device=args.device,
+            output=args.output,
+        )
+    except (ValueError, ImportError, RuntimeError) as e:
+        _log.error(str(e))
+        sys.exit(1)
+
+    if args.validate:
+        device = args.device or ("cuda" if _cuda_available() else "cpu")
+        ok = validate(args.model, onnx_dir, device=device)
+        sys.exit(0 if ok else 1)
+
+
+def _cuda_available() -> bool:
+    try:
+        import torch
+
+        return torch.cuda.is_available()
+    except ImportError:
+        return False
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/convert_onnx.py
+++ b/tools/convert_onnx.py
@@ -122,6 +122,15 @@ def convert(
             "Run --list to see eligible models."
         )
 
+    # Resolve output dir early so we can check the cache before importing optimum
+    onnx_dir = output or _onnx_cache_dir(model_name)
+
+    if _is_converted(onnx_dir):
+        _log.info(
+            "ONNX model already exists — skipping conversion (use --force to re-convert)."
+        )
+        return onnx_dir
+
     # Lazy import — only required when converting
     try:
         from optimum.onnxruntime import (
@@ -146,18 +155,11 @@ def convert(
             device = "cpu"
 
     provider = _resolve_provider(device)
-    onnx_dir = output or _onnx_cache_dir(model_name)
 
     _log.info(f"Model:     {model_name}")
     _log.info(f"Optimize:  {optimize}")
     _log.info(f"Device:    {device} ({provider})")
     _log.info(f"Output:    {onnx_dir}")
-
-    if _is_converted(onnx_dir):
-        _log.info(
-            "ONNX model already exists — skipping conversion (use --force to re-convert)."
-        )
-        return onnx_dir
 
     onnx_dir.mkdir(parents=True, exist_ok=True)
 
@@ -235,6 +237,10 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
     Encodes 10 code-like sentences with both backends. Passes if max cosine diff < 0.001
     (threshold from the Optimum notebook benchmark: GEMM GELU max diff was 0.0004).
 
+    Pooling strategy is read from MODEL_REGISTRY["onnx_pooling"] and must match
+    what ONNXEmbeddingModel uses — otherwise validation results are meaningless for
+    mean-pooling models (e.g. Qwen3-Embedding-0.6B, embeddinggemma-300m).
+
     Args:
         model_name: Original HuggingFace model name for PyTorch reference.
         onnx_dir: Directory containing the optimized ONNX model.
@@ -273,6 +279,15 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
         _log.error(f"optimum not available: {e}")
         return False
 
+    # Resolve pooling strategy from MODEL_REGISTRY (default: "cls")
+    try:
+        from search.config import MODEL_REGISTRY
+
+        pooling = MODEL_REGISTRY.get(model_name, {}).get("onnx_pooling", "cls")
+    except ImportError:
+        pooling = "cls"
+    _log.info(f"Pooling strategy: {pooling!r} (from MODEL_REGISTRY)")
+
     provider = _resolve_provider(device)
 
     # Load PyTorch reference model
@@ -296,8 +311,14 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
     )
     with torch.no_grad():
         ort_out = ort_model(**encoded)
-    # CLS pooling (position 0 of last_hidden_state)
-    onnx_embeddings = ort_out.last_hidden_state[:, 0, :]
+    last_hidden = ort_out.last_hidden_state  # (N, seq_len, dim)
+    if pooling == "mean":
+        attention_mask = encoded["attention_mask"]
+        mask_expanded = attention_mask.unsqueeze(-1).float()
+        onnx_embeddings = (last_hidden * mask_expanded).sum(dim=1)
+        onnx_embeddings = onnx_embeddings / mask_expanded.sum(dim=1).clamp(min=1e-9)
+    else:  # cls
+        onnx_embeddings = last_hidden[:, 0, :]
     onnx_embeddings = F.normalize(onnx_embeddings.float(), p=2, dim=1)
 
     # Compute diffs


### PR DESCRIPTION
## Summary

- Adds ONNX Runtime inference backend with auto-conversion pipeline (`embeddings/onnx_loader.py`, `onnx_wrapper.py`, `tools/convert_onnx.py`)
- 104-test unit suite: loader, wrapper, model_loader integration, convert tool
- Fixes: unsupported-arch handling, cuDNN-missing CUDA ORT detection
- Fixes 4 early ONNX flaws: cleanup leak, VRAM blindness, batch calc, session compat

## Commits

- `88d7d53` feat: add ONNX Runtime inference support with auto-conversion pipeline
- `d80baab` test: add comprehensive ONNX pipeline unit tests (104 tests); fix validate() pooling bug and convert() early-return ordering
- `b93d691` fix: handle unsupported ONNX archs + cuDNN-missing CUDA ORT
- `5a3d758` fix: resolve 4 ONNX flaws — cleanup leak, VRAM blindness, batch calc, session compat

## Test plan

- [ ] CI: ruff + pytest unit suite
- [ ] CI: Claude Code Review
- [ ] CI: Gemini Review

🤖 Stacked PR 1/4 — base for PRs 2–4