### PR TITLE
fix: ONNX VRAM accuracy, cost overrides, and Mistral logging polish

### DIFF
--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -67,6 +67,14 @@ MODEL_ACTIVATION_COST_OVERRIDES: dict[str, float] = {
     # Note: PyTorch caching allocator inflates driver-level VRAM readings;
     # this value is based on batch sizing safety, not raw mem_get_info deltas.
     "Qwen/Qwen3-Embedding-0.6B": 0.27,
+    # BGE-M3 (ONNX): ORT CUDAExecutionProvider uses ~0.28 GB/item activation.
+    # Measured via Task Manager: 4.5GB activations for batch=16 → 0.28 GB/item.
+    # ORT has no in-place optimization and uses a separate allocator, so per-item
+    # cost is ~3.5x higher than the PyTorch medium tier (0.08 GB/item).
+    "BAAI/bge-m3": 0.28,
+    # GTE-ModernBERT (ONNX): smaller 768-dim model, estimated from ONNX overhead pattern.
+    # Conservative estimate pending empirical measurement on RTX 3070.
+    "Alibaba-NLP/gte-modernbert-base": 0.15,
 }
 
 

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -72,9 +72,10 @@ MODEL_ACTIVATION_COST_OVERRIDES: dict[str, float] = {
     # ORT has no in-place optimization and uses a separate allocator, so per-item
     # cost is ~3.5x higher than the PyTorch medium tier (0.08 GB/item).
     "BAAI/bge-m3": 0.28,
-    # GTE-ModernBERT (ONNX): smaller 768-dim model, estimated from ONNX overhead pattern.
-    # Conservative estimate pending empirical measurement on RTX 3070.
-    "Alibaba-NLP/gte-modernbert-base": 0.15,
+    # GTE-ModernBERT (ONNX): 768-dim, ORT overhead measured via shared memory spill.
+    # batch=22 at 0.15 GB/item spilled to shared memory on RTX 3070 (8GB).
+    # Increased to 0.25 GB/item to keep dedicated VRAM under capacity.
+    "Alibaba-NLP/gte-modernbert-base": 0.25,
 }
 
 

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -67,6 +67,15 @@ MODEL_ACTIVATION_COST_OVERRIDES: dict[str, float] = {
     # Note: PyTorch caching allocator inflates driver-level VRAM readings;
     # this value is based on batch sizing safety, not raw mem_get_info deltas.
     "Qwen/Qwen3-Embedding-0.6B": 0.27,
+}
+
+# ONNX Runtime-measured overrides — ORT's CUDAExecutionProvider uses a separate
+# BFCArena allocator with no in-place activation reuse, so per-item cost differs
+# substantially from the PyTorch path for the same model.
+# These values must NOT be applied when the model loads via the PyTorch fallback
+# (e.g. when use_onnx=true but optimum is unavailable), which is why they live in
+# a separate table consulted only when backend="onnx".
+MODEL_ACTIVATION_COST_OVERRIDES_ONNX: dict[str, float] = {
     # BGE-M3 (ONNX): ORT CUDAExecutionProvider uses ~0.28 GB/item activation.
     # Measured via Task Manager: 4.5GB activations for batch=16 → 0.28 GB/item.
     # ORT has no in-place optimization and uses a separate allocator, so per-item
@@ -79,25 +88,37 @@ MODEL_ACTIVATION_COST_OVERRIDES: dict[str, float] = {
 }
 
 
-def _get_activation_cost_override(model_name: str) -> float | None:
-    """Look up activation cost override with fuzzy model name matching.
+def _get_activation_cost_override(
+    model_name: str, backend: str = "pytorch"
+) -> float | None:
+    """Look up activation cost override for (model_name, backend).
 
     Supports exact match, suffix match, and substring match to handle
     local paths and variant names (e.g., "/path/to/nomic-ai/CodeRankEmbed").
 
+    ONNX-measured overrides (MODEL_ACTIVATION_COST_OVERRIDES_ONNX) are only
+    returned when backend="onnx", preventing them from being applied when a
+    model falls back to the PyTorch path (e.g. optimum not installed).
+
     Args:
         model_name: Model identifier (may be HF ID or local path)
+        backend: Inference backend — "onnx" or "pytorch" (default)
 
     Returns:
         Override cost in GB per item, or None if no match
     """
     if model_name is None:
         return None
+    table = (
+        MODEL_ACTIVATION_COST_OVERRIDES_ONNX
+        if backend == "onnx"
+        else MODEL_ACTIVATION_COST_OVERRIDES
+    )
     # Exact match first (fastest path)
-    if model_name in MODEL_ACTIVATION_COST_OVERRIDES:
-        return MODEL_ACTIVATION_COST_OVERRIDES[model_name]
+    if model_name in table:
+        return table[model_name]
     # Fuzzy match: suffix or substring
-    for key, cost in MODEL_ACTIVATION_COST_OVERRIDES.items():
+    for key, cost in table.items():
         if model_name.endswith(key) or key in model_name:
             return cost
     return None
@@ -197,6 +218,7 @@ def calculate_optimal_batch_size(
     memory_fraction: float = 0.8,  # Target 80% VRAM utilization (20% headroom)
     model_vram_gb: float = 0.0,
     model_name: str | None = None,
+    backend: str = "pytorch",
 ) -> int:
     """Calculate optimal batch size using model-aware activation memory estimation.
 
@@ -260,7 +282,7 @@ def calculate_optimal_batch_size(
         # Check for model-specific activation cost overrides first
         # Some models have activation memory that doesn't correlate with their weight VRAM
         # (e.g., CodeRankEmbed: small weight but long context → high activation memory)
-        override_cost = _get_activation_cost_override(model_name)
+        override_cost = _get_activation_cost_override(model_name, backend=backend)
         if override_cost is not None:
             gb_per_item = override_cost
             model_tier = "override"
@@ -929,6 +951,7 @@ class CodeEmbedder:
                     0.05, min(memory_fraction, 0.95)
                 )  # Clamp to safe range
 
+                _backend = "onnx" if hasattr(self._model, "ort_model") else "pytorch"
                 batch_size = calculate_optimal_batch_size(
                     embedding_dim=config.embedding.dimension,
                     min_batch=config.performance.dynamic_batch_min,
@@ -936,6 +959,7 @@ class CodeEmbedder:
                     memory_fraction=memory_fraction,
                     model_vram_gb=model_vram_gb,
                     model_name=self.model_name,
+                    backend=_backend,
                 )
                 self._logger.info(
                     f"Using dynamic GPU-optimized batch size {batch_size} for {len(chunks)} chunks"

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -302,9 +302,6 @@ class ModelLoader:
         )
         ort_model, tokenizer, device = loader.load()
 
-        post_vram_bytes = _get_nvml_used_bytes(device)
-        vram_delta_gb = max(0.0, (post_vram_bytes - pre_vram_bytes) / (1024**3))
-
         wrapper = ONNXEmbeddingModel(
             ort_model=ort_model,
             tokenizer=tokenizer,
@@ -312,6 +309,21 @@ class ModelLoader:
             pooling=pooling,
             model_name=self.model_name,
         )
+
+        # Warmup inference: ORT CUDAExecutionProvider defers bulk CUDA allocation to
+        # first inference. Without warmup, the pynvml delta only captures session setup
+        # overhead (~0.5GB) rather than the full runtime footprint (~1.5-2.5GB).
+        if device == "cuda":
+            try:
+                wrapper.encode(["warmup"], batch_size=1)
+                self._logger.debug(
+                    "[ONNX] Warmup inference complete — CUDA memory now allocated"
+                )
+            except Exception as e:
+                self._logger.debug(f"[ONNX] Warmup failed (non-fatal): {e}")
+
+        post_vram_bytes = _get_nvml_used_bytes(device)
+        vram_delta_gb = max(0.0, (post_vram_bytes - pre_vram_bytes) / (1024**3))
         wrapper._vram_gb = (
             vram_delta_gb  # used by _get_model_vram_gb() for batch sizing
         )

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -319,8 +319,10 @@ class ModelLoader:
                 self._logger.debug(
                     "[ONNX] Warmup inference complete — CUDA memory now allocated"
                 )
-            except Exception as e:
-                self._logger.debug(f"[ONNX] Warmup failed (non-fatal): {e}")
+            except Exception:
+                # Preserve traceback for diagnostics while keeping severity at debug —
+                # warmup failure is non-fatal (batch sizing falls back to setup-only VRAM).
+                self._logger.debug("[ONNX] Warmup failed (non-fatal)", exc_info=True)
 
         post_vram_bytes = _get_nvml_used_bytes(device)
         vram_delta_gb = max(0.0, (post_vram_bytes - pre_vram_bytes) / (1024**3))

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -348,16 +348,27 @@ class ModelLoader:
             RuntimeError: If model loading fails after all recovery attempts
         """
         # ONNX fast path — bypasses PyTorch loading entirely when enabled.
-        # If optimum[onnxruntime] is not installed (optional dep), ONNX load
-        # raises ImportError from onnx_loader._convert_model(); catch it and
-        # fall through to the PyTorch path so fresh installs without the ONNX
-        # extra don't hard-fail on first model load.
+        # Falls back to PyTorch on:
+        #   - ImportError: optimum[onnxruntime] not installed (fresh install without
+        #     the ONNX extra).
+        #   - RuntimeError: ONNX export, optimization, or runtime load failed
+        #     (e.g. unsupported architecture, corrupted cache, missing optimum
+        #     symbol). With use_onnx=true as the default, swallowing these here
+        #     prevents a hard startup failure on environments where ORT can't run
+        #     the requested model — at the cost of silently changing backends.
+        # Both paths log a loud warning so the backend switch is visible in logs.
         if self._should_use_onnx():
             try:
                 return self._load_onnx()
             except ImportError as e:
                 self._logger.warning(
                     f"[ONNX] Falling back to PyTorch — optimum not installed: {e}"
+                )
+            except RuntimeError as e:
+                self._logger.warning(
+                    f"[ONNX] Falling back to PyTorch — ONNX load/conversion "
+                    f"failed: {e}",
+                    exc_info=True,
                 )
 
         if SentenceTransformer is None:

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -244,12 +244,28 @@ class ONNXModelLoader:
             # Optimum's default file resolution looks for "model.onnx" but our
             # optimized export produces "model_optimized.onnx" — passing file_name
             # explicitly silences the "could not find model.onnx" warning.
-            model_file = "model_optimized.onnx"  # O4-optimized default
+            #
+            # convert_meta.json is read from a user-controlled cache directory, so
+            # we treat `model_file` as untrusted: strip any path components, require
+            # the .onnx extension, and fall back to the safe default if the resolved
+            # path does not actually exist inside _onnx_dir.
+            default_model_file = "model_optimized.onnx"
+            model_file = default_model_file
             meta_path = self._onnx_dir / "convert_meta.json"
             if meta_path.is_file():
                 try:
                     meta = json.loads(meta_path.read_text())
-                    model_file = meta.get("model_file", model_file)
+                    candidate = Path(meta.get("model_file", default_model_file)).name
+                    if (
+                        candidate.endswith(".onnx")
+                        and (self._onnx_dir / candidate).is_file()
+                    ):
+                        model_file = candidate
+                    else:
+                        _log.warning(
+                            f"[ONNX] Ignoring invalid model_file in convert_meta.json: "
+                            f"{meta.get('model_file')!r} — using {default_model_file!r}"
+                        )
                 except Exception:
                     pass
 

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import json
 import logging
-import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -254,8 +253,13 @@ class ONNXModelLoader:
                 except Exception:
                     pass
 
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", message=".*incorrect regex pattern.*")
+            # Suppress benign "incorrect regex pattern" warning from transformers.
+            # BGE-M3 uses a Mistral-derived tokenizer that triggers this via logger.warning()
+            # (not warnings.warn), so we must temporarily raise the transformers log level.
+            _transformers_logger = logging.getLogger("transformers")
+            _prev_level = _transformers_logger.level
+            _transformers_logger.setLevel(logging.ERROR)
+            try:
                 ort_model = ORTModelForFeatureExtraction.from_pretrained(
                     str(self._onnx_dir),
                     file_name=model_file,
@@ -267,6 +271,8 @@ class ONNXModelLoader:
                 except Exception:
                     # Unoptimized fallback exports may not have tokenizer files in the ONNX dir
                     tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            finally:
+                _transformers_logger.setLevel(_prev_level)
         except Exception as e:
             raise RuntimeError(
                 f"[ONNX] Failed to load from {self._onnx_dir}: {e}\n"

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -51,7 +51,11 @@ def _is_converted(onnx_dir: Path) -> bool:
 
 
 def _resolve_provider(device: str) -> str:
-    if device == "cuda":
+    # Accept any CUDA device form: "cuda", "cuda:0", "cuda:1", etc.
+    # The device index is handled by the CUDAExecutionProvider itself via
+    # provider_options or the current torch.cuda device — we only need to pick
+    # the right EP here.
+    if device.startswith("cuda"):
         return "CUDAExecutionProvider"
     return "CPUExecutionProvider"
 
@@ -107,7 +111,10 @@ def _convert_model(model_name: str, onnx_dir: Path, device: str) -> None:
             "Set use_onnx: false in search_config.json to use PyTorch instead."
         ) from e
 
-    # Step 2: Apply O4 optimization + GEMM GELU fusion
+    # Step 2: Apply O4 optimization + GEMM GELU fusion.
+    # For architectures not yet supported by ORTOptimizer (e.g. gemma3, qwen3),
+    # fall back to saving the unoptimized ONNX export so the model is still
+    # usable for inference. Mirrors the CLI tool's behaviour in tools/convert_onnx.py.
     _log.info(f"[ONNX] Step 2/2: Applying {_DEFAULT_OPTIMIZE} + GEMM GELU fusion...")
     try:
         optimizer = ORTOptimizer.from_pretrained(ort_model)
@@ -120,7 +127,28 @@ def _convert_model(model_name: str, onnx_dir: Path, device: str) -> None:
             optimization_config=optimization_config,
         )
     except Exception as e:
-        raise RuntimeError(f"[ONNX] Optimization failed: {e}") from e
+        _unsupported = "not available yet" in str(
+            e
+        ) or "doesn't support the graph optimization" in str(e)
+        if _unsupported:
+            _log.warning(
+                "[ONNX] ORTOptimizer does not support this architecture — "
+                "saving unoptimized model."
+            )
+            _log.warning(f"[ONNX]   Reason: {e}")
+            ort_model.save_pretrained(str(onnx_dir))
+        else:
+            raise RuntimeError(f"[ONNX] Optimization failed: {e}") from e
+
+    # Save tokenizer alongside the model so subsequent loads don't have to
+    # re-download from HuggingFace (the load-time fallback is functional but
+    # adds latency on first ORT load and breaks offline use).
+    try:
+        from transformers import AutoTokenizer
+
+        AutoTokenizer.from_pretrained(model_name).save_pretrained(str(onnx_dir))
+    except Exception as tok_err:
+        _log.warning(f"[ONNX] Could not save tokenizer to {onnx_dir}: {tok_err}")
 
     # Write metadata
     try:

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -267,7 +267,11 @@ class ONNXModelLoader:
                             f"{meta.get('model_file')!r} — using {default_model_file!r}"
                         )
                 except Exception:
-                    pass
+                    _log.debug(
+                        "[ONNX] Failed to parse convert_meta.json — "
+                        f"using default model file {default_model_file!r}",
+                        exc_info=True,
+                    )
 
             # Suppress benign "incorrect regex pattern" warning from transformers.
             # BGE-M3 uses a Mistral-derived tokenizer that triggers this via logger.warning()

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -230,6 +230,9 @@ class ONNXModelLoader:
         _log.info(
             f"[ONNX] Loading {self.model_name!r} from {self._onnx_dir} via {provider}"
         )
+        # Suppress benign upstream tokenizer warning about incorrect regex pattern.
+        # BGE-M3 (and Mistral-derived tokenizer configs) emit this during both
+        # ORTModelForFeatureExtraction.from_pretrained() and AutoTokenizer.from_pretrained().
         try:
             import onnxruntime as ort
 
@@ -251,23 +254,19 @@ class ONNXModelLoader:
                 except Exception:
                     pass
 
-            ort_model = ORTModelForFeatureExtraction.from_pretrained(
-                str(self._onnx_dir),
-                file_name=model_file,
-                provider=provider,
-                session_options=session_options,
-            )
-            try:
-                # Suppress benign upstream tokenizer warning about incorrect regex pattern
-                # (affects BGE-M3 and models derived from Mistral tokenizer configs).
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        "ignore", message=".*incorrect regex pattern.*"
-                    )
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=".*incorrect regex pattern.*")
+                ort_model = ORTModelForFeatureExtraction.from_pretrained(
+                    str(self._onnx_dir),
+                    file_name=model_file,
+                    provider=provider,
+                    session_options=session_options,
+                )
+                try:
                     tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
-            except Exception:
-                # Unoptimized fallback exports may not have tokenizer files in the ONNX dir
-                tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+                except Exception:
+                    # Unoptimized fallback exports may not have tokenizer files in the ONNX dir
+                    tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         except Exception as e:
             raise RuntimeError(
                 f"[ONNX] Failed to load from {self._onnx_dir}: {e}\n"

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -237,13 +238,33 @@ class ONNXModelLoader:
             # assigns shape-related ops to CPU; the messages are noise, not errors.
             session_options.log_severity_level = 3  # ERROR only (0=VERBOSE, 3=ERROR)
 
+            # Resolve the ONNX model filename from conversion metadata.
+            # Optimum's default file resolution looks for "model.onnx" but our
+            # optimized export produces "model_optimized.onnx" — passing file_name
+            # explicitly silences the "could not find model.onnx" warning.
+            model_file = "model_optimized.onnx"  # O4-optimized default
+            meta_path = self._onnx_dir / "convert_meta.json"
+            if meta_path.is_file():
+                try:
+                    meta = json.loads(meta_path.read_text())
+                    model_file = meta.get("model_file", model_file)
+                except Exception:
+                    pass
+
             ort_model = ORTModelForFeatureExtraction.from_pretrained(
                 str(self._onnx_dir),
+                file_name=model_file,
                 provider=provider,
                 session_options=session_options,
             )
             try:
-                tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
+                # Suppress benign upstream tokenizer warning about incorrect regex pattern
+                # (affects BGE-M3 and models derived from Mistral tokenizer configs).
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        "ignore", message=".*incorrect regex pattern.*"
+                    )
+                    tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))
             except Exception:
                 # Unoptimized fallback exports may not have tokenizer files in the ONNX dir
                 tokenizer = AutoTokenizer.from_pretrained(self.model_name)

--- a/mcp_server/tools/status_handlers.py
+++ b/mcp_server/tools/status_handlers.py
@@ -201,7 +201,10 @@ async def handle_get_memory_status(arguments: dict[str, Any]) -> dict:
     # GPU memory — use pynvml for real VRAM (ORT allocates outside PyTorch allocator)
     gpu_memory = {}
     if torch.cuda.is_available():
-        # Try pynvml for actual VRAM used by this process (includes ORT allocations)
+        # Try pynvml for device-wide VRAM (sum of all processes + drivers + ORT).
+        # NOTE: nvmlDeviceGetMemoryInfo().used is NOT per-process; it reflects total
+        # allocations on the GPU. A proper per-process reading would require
+        # nvmlDeviceGetComputeRunningProcesses() filtered by os.getpid().
         nvml_available = False
         try:
             import pynvml

--- a/search_config.json
+++ b/search_config.json
@@ -32,7 +32,7 @@
     "enable_entity_tracking": true,
     "prefer_gpu": true,
     "vram_limit_fraction": 0.8,
-    "allow_ram_fallback": false,
+    "allow_ram_fallback": true,
     "enable_fp16": true,
     "prefer_bf16": true,
     "enable_dynamic_batch_size": true,

--- a/tools/convert_onnx.py
+++ b/tools/convert_onnx.py
@@ -351,14 +351,17 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
         onnx_embeddings = last_hidden[:, 0, :]
     onnx_embeddings = F.normalize(onnx_embeddings.float(), p=2, dim=1)
 
-    # Compute diffs
+    # Compute element-wise absolute differences between L2-normalised embeddings.
+    # This is the same metric the Optimum benchmark uses (max diff 0.0004 for
+    # GEMM GELU fusion vs 0.0011 for gelu_approximation), NOT cosine distance —
+    # earlier versions of this log line were mislabelled.
     diffs = (pt_embeddings.cpu() - onnx_embeddings.cpu()).abs()
     max_diff = float(diffs.max())
     mean_diff = float(diffs.mean())
     threshold = 0.001
 
-    _log.info(f"Max cosine diff:  {max_diff:.6f}  (threshold: {threshold})")
-    _log.info(f"Mean cosine diff: {mean_diff:.6f}")
+    _log.info(f"Max abs diff:  {max_diff:.6f}  (threshold: {threshold})")
+    _log.info(f"Mean abs diff: {mean_diff:.6f}")
 
     if max_diff <= threshold:
         _log.info("Quality gate PASSED ✓")


### PR DESCRIPTION
## Summary

- Accurate ONNX VRAM measurement via warmup path (not just config hints). ORT's `CUDAExecutionProvider` defers bulk CUDA allocation to first inference, so a warmup call is required to capture the true runtime footprint for dynamic batch sizing.
- Per-item cost overrides for GTE-ModernBERT and others.
- Suppress noisy Mistral regex warning at ORT load via logging level (not `warnings` module).
- **Behavior change (intentional)**: restores `"allow_ram_fallback": true` in `search_config.json` (was tightened to `false` during ONNX stabilization in PR #20). With the ORT path now stable and the WDDM hard-limit work in PR #23, the generic PyTorch fallback is safe to re-enable as the default. If you're running on a host where unintended RAM fallback would be catastrophic, keep it `false` in your deployment-specific config.

## Review follow-up (force-pushed after initial CI review)

- **A — Warmup exc_info**: `wrapper.encode(["warmup"]...)` failure log now uses `exc_info=True` to preserve the stack trace (still at `debug` severity — warmup failure remains non-fatal). Commit `81a0b81`.
- **C — `model_file` path-traversal hardening**: `convert_meta.json`'s `model_file` value is treated as untrusted: normalized via `Path(x).name` (drops any separators/traversal), required to have `.onnx` extension, and verified to exist inside `_onnx_dir`. Falls back to `model_optimized.onnx` and warns if invalid. Commit `37f8c25`.
- **B — `transformers` logger level raise**: deferred. The current `try/finally` restores the level deterministically, so the global-state window is brief. A `logging.Filter`-based approach is cleaner for concurrent loads but a medium-size refactor; tracked as follow-up.

## Commits

- `71938f6` fix: accurate ONNX VRAM via warmup, correct per-item cost overrides, suppress warnings
- `07dff2c` fix: increase GTE-ModernBERT ONNX cost override
- `b6fe9c1` fix: suppress Mistral regex warning via logging level
- `81a0b81` fix: preserve warmup failure traceback via exc_info
- `37f8c25` fix: validate model_file from convert_meta.json against path traversal

## Test plan

- [ ] CI: ruff + pytest unit suite
- [ ] CI: Claude Code Review
- [ ] CI: Gemini Review

🤖 Stacked PR 2/4 — depends on PR #20