### PR TITLE
fix: WDDM VRAM spillover — PyTorch + ORT hard limit with OOM recovery

### DIFF
--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -34,6 +34,50 @@ This file maintains session memory and context for the Claude-context-MCP semant
 
 ## Session History
 
+### 2026-04-16: VRAM Hard-Limit Fix — Account for Other-Process Allocation
+
+**Primary Achievement**: Fixed Windows WDDM shared-memory spillover bug where `set_vram_limit()` applied the process cap against total GPU memory without subtracting VRAM already held by other processes, causing embedding streams to spill to system RAM when other apps occupied VRAM.
+
+#### Key Accomplishments
+
+- Diagnosed root cause: `torch.cuda.set_per_process_memory_fraction(fraction, device=0)` was using `fraction × total_memory` as the cap, so a 10 GB external allocation on a 24 GB GPU was invisible to the 19.2 GB cap — combined demand 29.2 GB triggered WDDM shared-memory eviction
+- Rewrote `set_vram_limit()` to compute an *effective* fraction from live `mem_get_info()` + `memory_allocated()` readings, capping our process at `min(user_cap, A_us + F − headroom)` so the hard limit respects physically available VRAM
+- Added automatic re-application of the cap at the start of `embed_chunks()` so mid-session VRAM pressure (browser, game, reranker loading) is accounted for at embedding time
+- Added re-apply before each of the three reranker lazy-load sites (`NeuralReranker`, `GenerativeReranker`, `JinaRerankerV3`) so model loads also see current free VRAM
+- 8 new unit tests covering: no-pressure baseline, 10 GB other-process scenario (the bug), mid-run re-apply, clamp-up when physical cap < current usage, `allow_ram_fallback` short-circuit, no CUDA, raise, idempotency
+- All 964 unit tests (224 embeddings + 740 search) pass; lint clean
+
+#### Technical Details
+
+**Formula** (`T`=total, `F`=free, `A_us`=our allocated, `A_other = max(0, T−F−A_us)`, `r`=requested fraction):
+```
+headroom     = (1 − r) × T
+physical_cap = A_us + F − headroom   (== T − A_other − headroom)
+cap          = max(min(r×T, physical_cap), A_us)
+effective_fraction = clamp(cap / T, 0.05, r)
+```
+
+Example — 24 GB GPU, `r=0.8`, other process holds 10 GB: `effective_fraction ≈ 0.383` instead of 0.80. Combined usage at saturation: 9.2 + 10 = 19.2 GB ≤ 24 GB physical. No WDDM spill.
+
+New log format: `[VRAM_LIMIT] Requested=80%, effective=38% (free=14.0GB, us=0.0GB, other=10.0GB, headroom=4.8GB)`
+
+The `allow_ram_fallback=True` short-circuit is preserved verbatim — cap is skipped entirely in that mode.
+
+Not covered (documented in `set_vram_limit()` docstring): FAISS GPU allocator and ORT CUDAExecutionProvider both use separate CUDA allocators that `set_per_process_memory_fraction` does not govern.
+
+#### Files Modified
+
+- `embeddings/embedder.py` — `set_vram_limit()` rewritten with effective-fraction formula; re-apply call inserted at top of `embed_chunks()` after model warmup
+- `search/neural_reranker.py` — VRAM cap re-applied before lazy load in `NeuralReranker.model`, `GenerativeReranker._ensure_loaded()`, `JinaRerankerV3._load_or_fetch()`
+- `tests/unit/embeddings/test_embedder.py` — `TestSetVramLimitEffective` class (8 tests)
+- `docs/INSTALLATION_GUIDE.md` — Windows VRAM auto-adjustment note in VRAM Limit Fraction section
+
+#### Commit
+
+- `a209849` — fix: account for other-process VRAM allocation in hard limit to prevent WDDM spillover
+
+---
+
 ### 2026-04-10: SSCG Three-Mode Evaluation & Golden Dataset Fix
 
 **Primary Achievement**: Completed three-mode (hybrid/BM25/semantic) SSCG evaluation via live MCP server, identified 4 broken golden labels and 3 oversized expected sets, fixed all issues — benchmark now passes all thresholds with 13/13 Hit Rate across all modes.

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -34,6 +34,45 @@ This file maintains session memory and context for the Claude-context-MCP semant
 
 ## Session History
 
+### 2026-04-16: ONNX Runtime VRAM Cap + OOM Recovery (Fixes A & B)
+
+**Primary Achievement**: Extended the WDDM spillover fix to the active ONNX Runtime backend by capping ORT's CUDA arena and adding BFCArena-aware OOM recovery with batch-size backoff, eliminating VRAM spillover end-to-end on 8 GB laptop GPUs.
+
+#### Key Accomplishments
+
+- Constrained ORT `CUDAExecutionProvider` allocator via `gpu_mem_limit` + `arena_extend_strategy="kSameAsRequested"` — the critical missing piece, since `torch.cuda.set_per_process_memory_fraction` does not govern ORT's allocator
+- Extracted `compute_effective_vram_cap(fraction)` as a shared helper returning `(effective_fraction, cap_bytes, free_gb, us_gb, other_gb, headroom_gb)` so PyTorch and ORT compute identical caps
+- **Fix A (budget-aware batch sizing)**: `calculate_optimal_batch_size()` now accepts `ort_cap_gb` and constrains `available_gb = min(free_gb, ort_cap_gb − model_vram_gb)` so dynamic batching respects the ORT session arena, not just raw free VRAM
+- **Fix B (OOM backoff)**: Converted `embed_chunks()` batch loop from `for` to `while` with mutable `current_batch_size`; on BFCArena/RuntimeError OOM, halve the batch, `empty_cache()`, re-sync `progress.update(total=...)`, and retry — no user-visible failure
+- Added `onnx_gpu_mem_limit: bool = True` config flag; documented ORT cap behavior and updated 8 GB tier guidance in `INSTALLATION_GUIDE.md`
+- 6 new unit tests: `TestCalculateOptimalBatchSizeOrtCap` (3) + `TestOomRecoveryBackoff` (3); full suite 1975/1975 pass
+- Live validation on RTX 4060 Laptop: gte-modernbert 32→16, bge-m3 16→8 after OOM, 3120 chunks in 143.80s, **zero shared-memory spillover**
+
+#### Technical Details
+
+**ORT cap plumbing** (`onnx_loader.py`): on `CUDAExecutionProvider`, build `provider_options=[{"gpu_mem_limit": int(cap_bytes), "arena_extend_strategy": "kSameAsRequested"}]` from `compute_effective_vram_cap()` and pass to `ORTModelForFeatureExtraction.from_pretrained(...)`. Gated behind `performance.onnx_gpu_mem_limit`; decoupled from `allow_ram_fallback` so the ORT cap applies even when PyTorch fallback is permitted. New `[ONNX_VRAM]` log line mirrors `[VRAM_LIMIT]` format.
+
+**OOM recovery pattern** (`embedder.py`): `except RuntimeError as e:` checks `"out of memory" | "bfcarena" | ("available memory" & "smaller than requested")` substrings. On match with `current_batch_size > 1`: halve, recompute `remaining_batches = ceil((len−i) / new_size)`, `progress.update(task, total=completed + remaining_batches)`, `empty_cache()`, `gc.collect()`, `batch_num -= 1`, `continue`. Reduced batch size persists for subsequent batches, so cost is paid once per file. `torch.cuda.OutOfMemoryError` is a `RuntimeError` subclass, so listing both caused `TypeError` when `torch` was mocked — fixed by catching `RuntimeError` only.
+
+**ORT cap detection at call site**: `embed_chunks()` reads `ort_cap_gb` via `compute_effective_vram_cap()` when the model has an `ort_model` attribute, then passes it to `calculate_optimal_batch_size()` for the initial size guess.
+
+#### Files Modified
+
+- `embeddings/embedder.py` — extracted `compute_effective_vram_cap()`; added `ort_cap_gb` param to `calculate_optimal_batch_size()`; converted `embed_chunks()` batch loop to while+mutable size with BFCArena-aware OOM handler
+- `embeddings/onnx_loader.py` — provider_options with `gpu_mem_limit` + `kSameAsRequested` for `CUDAExecutionProvider`; gated by `onnx_gpu_mem_limit` config flag
+- `search/config.py` — `onnx_gpu_mem_limit: bool = True` added to `PerformanceConfig`
+- `search_config.json` — `"onnx_gpu_mem_limit": true` under `"performance"`
+- `tests/unit/embeddings/test_embedder.py` — `TestComputeEffectiveVramCap`, `TestCalculateOptimalBatchSizeOrtCap`, `TestOomRecoveryBackoff` classes
+- `tests/unit/embeddings/test_onnx_loader.py` — provider_options assertions (CUDA + CPU + flag-disabled cases)
+- `docs/INSTALLATION_GUIDE.md` — ORT cap documentation in VRAM Limit Fraction section; revised 8 GB tier guidance
+
+#### Commits
+
+- `457648b` — fix: constrain ORT CUDAExecutionProvider arena to prevent WDDM VRAM spillover
+- `7b90388` — fix: ORT-aware batch sizing + BFCArena OOM recovery (fix B+A)
+
+---
+
 ### 2026-04-16: VRAM Hard-Limit Fix — Account for Other-Process Allocation
 
 **Primary Achievement**: Fixed Windows WDDM shared-memory spillover bug where `set_vram_limit()` applied the process cap against total GPU memory without subtracting VRAM already held by other processes, causing embedding streams to spill to system RAM when other apps occupied VRAM.

--- a/docs/INSTALLATION_GUIDE.md
+++ b/docs/INSTALLATION_GUIDE.md
@@ -1052,6 +1052,16 @@ Two new settings are available to manage GPU memory allocation on systems with l
 2. **Hard Ceiling**: `vram_limit_fraction` (80%) enforces VRAM limit
 3. **Spillover Control**: `allow_ram_fallback` (false) prevents slow shared memory usage
 
+**Automatic adjustment for other processes (Windows)**:
+
+On Windows, the effective VRAM cap is automatically reduced when other processes
+(browsers, games, other ML workloads) hold GPU memory at runtime. At each embedding
+run and model load, the system re-measures free and allocated VRAM and derives an
+effective fraction that prevents our process from overcommitting physical VRAM —
+which would otherwise trigger the WDDM driver to evict memory to shared system RAM
+(10–100× slower than dedicated VRAM). Check `[VRAM_LIMIT]` log lines for the
+requested vs. effective fraction and the per-process breakdown.
+
 **When `allow_ram_fallback=true`**:
 
 - `vram_limit_fraction` is ignored (no hard limit set)

--- a/docs/INSTALLATION_GUIDE.md
+++ b/docs/INSTALLATION_GUIDE.md
@@ -1041,7 +1041,7 @@ Two new settings are available to manage GPU memory allocation on systems with l
 
 | GPU VRAM | Configuration | Notes |
 |----------|---------------|-------|
-| **8GB Laptop** | `allow_ram_fallback: true` | Reliability over speed |
+| **8GB Laptop** | `allow_ram_fallback: false`, `onnx_gpu_mem_limit: true` | Spill-free with ORT cap |
 | **10-12GB** | `vram_limit_fraction: 0.80` (default) | Balanced |
 | **16GB+** | `vram_limit_fraction: 0.85-0.90` | More headroom |
 | **24GB+** | `vram_limit_fraction: 0.90-0.95` | Maximum capacity |
@@ -1062,11 +1062,24 @@ which would otherwise trigger the WDDM driver to evict memory to shared system R
 (10–100× slower than dedicated VRAM). Check `[VRAM_LIMIT]` log lines for the
 requested vs. effective fraction and the per-process breakdown.
 
+**ONNX Runtime cap** (`onnx_gpu_mem_limit`, default `true`):
+
+When `use_onnx: true`, the embedding model runs via ORT's `CUDAExecutionProvider`,
+which has its own CUDA allocator that PyTorch's `set_per_process_memory_fraction`
+cannot govern. The `onnx_gpu_mem_limit` setting passes the same effective cap as
+ORT's `gpu_mem_limit` provider option at session creation, constraining the ORT
+arena directly. This is the primary spill-prevention mechanism on ONNX deployments.
+
+Check `[ONNX_VRAM]` log lines for the computed `gpu_mem_limit` and its breakdown.
+Disable (`onnx_gpu_mem_limit: false`) only for debugging — doing so re-exposes the
+ORT allocator to WDDM spillover when external processes hold VRAM.
+
 **When `allow_ram_fallback=true`**:
 
-- `vram_limit_fraction` is ignored (no hard limit set)
-- PyTorch can use system RAM when VRAM is full (slower but won't OOM)
-- Recommended for 8GB VRAM laptops to ensure neural reranker works reliably
+- `vram_limit_fraction` is ignored for the *PyTorch* allocator (no PyTorch hard cap set)
+- `onnx_gpu_mem_limit` is **not** affected — the ORT cap still applies independently
+- PyTorch can use system RAM when VRAM is full (slower but won't OOM for PyTorch ops)
+- Previously recommended for 8 GB laptops; no longer necessary with `onnx_gpu_mem_limit: true`
 
 **Configuration File**: Settings are persisted in `search_config.json` under `performance` section.
 

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -212,74 +212,45 @@ except ImportError:
     torch = None
 
 
-def set_vram_limit(fraction: float = 0.90) -> bool:
-    """Set hard VRAM limit to prevent shared memory spillover.
+def compute_effective_vram_cap(
+    fraction: float,
+) -> tuple[float, int, float, float, float, float] | None:
+    """Compute effective VRAM cap accounting for other-process allocations.
 
-    On Windows, the NVIDIA driver preemptively evicts to shared memory when
-    VRAM approaches capacity. This hard limit prevents that by raising OOM
-    errors instead of spilling (which is much faster than slow spillover).
+    Pure function — reads current GPU state, does not set any limits or produce
+    any side effects.  Call this from both the PyTorch-cap path
+    (``set_vram_limit``) and the ORT-cap path (``onnx_loader.py``) to ensure
+    both backends use identical budgets.
 
-    The effective fraction is computed dynamically from current free/allocated
-    VRAM so that memory held by other processes (browser, games, other ML jobs)
-    is subtracted from our budget.  This prevents the process cap from being set
-    above the physically available headroom, which would otherwise let our
-    allocations overcommit and trigger WDDM shared-memory spillover on Windows.
+    Formula::
 
-    It is safe and expected to call this function multiple times (e.g., at init
-    and again before each embedding run); each call re-measures the system state
-    and re-applies the cap.
-
-    If allow_ram_fallback is True in config, skip setting the limit to allow
-    slower but more reliable spillover to system RAM.
+        T            = total device VRAM
+        F            = system-wide free VRAM (excludes ALL processes)
+        A_us         = bytes our PyTorch process currently holds
+        A_other      = T - F - A_us  (held by every other process)
+        headroom     = (1 − fraction) × T   (safety reserve)
+        physical_cap = A_us + F − headroom  (max we can hold without spill)
+        cap          = max(min(user_cap, physical_cap), A_us)
+        effective_fraction = clamp(cap / T, 0.05, fraction)
 
     Args:
-        fraction: Requested fraction of dedicated VRAM (default: 0.90 = 90%).
-            The *effective* fraction may be lower when other processes hold VRAM.
-            Recommended: 0.80-0.90 depending on GPU headroom needs.
+        fraction: Requested fraction of total VRAM (0.05–1.0).
 
     Returns:
-        True if limit was set successfully, False otherwise.
+        ``(effective_fraction, cap_bytes, free_gb, us_gb, other_gb, headroom_gb)``
+        or ``None`` if CUDA is unavailable or measurement fails.
 
-    Note:
-        - Safe to call multiple times; re-application is idempotent.
-        - On ONNX models, the cap only constrains PyTorch operations.
-          ORT's CUDAExecutionProvider allocates memory outside PyTorch and
-          is not governed by this limit.
-        - FAISS GPU indexes use their own CUDA allocator and are also not
-          constrained by set_per_process_memory_fraction.
+        - *effective_fraction* — value for ``set_per_process_memory_fraction``
+        - *cap_bytes*          — value for ORT ``gpu_mem_limit`` provider option
+        - *free_gb / us_gb / other_gb / headroom_gb* — diagnostic values for logs
     """
     if not torch or not torch.cuda.is_available():
-        return False
-
-    # Check if RAM fallback is allowed
+        return None
     try:
-        config = _get_config_via_service_locator()
-        if config and config.performance.allow_ram_fallback:
-            logging.getLogger(__name__).info(
-                "[VRAM_LIMIT] RAM fallback allowed - skipping hard VRAM limit"
-            )
-            return True  # Don't set limit, allow spillover
-    except Exception as e:
-        logging.getLogger(__name__).debug(f"Config not available, using defaults: {e}")
-
-    logger = logging.getLogger(__name__)
-    try:
-        # Measure current VRAM state so the effective cap accounts for memory
-        # already held by other processes.
-        #   T = total device VRAM
-        #   F = system-wide free VRAM (excludes ALL processes)
-        #   A_us = bytes our PyTorch process currently holds
-        #   A_other = bytes held by every other process
         free_b, total_b = torch.cuda.mem_get_info(0)
         us_b = torch.cuda.memory_allocated(0)
         other_b = max(0, total_b - free_b - us_b)
 
-        # Formula (see docs for derivation):
-        #   user_cap     = fraction * T            — what the caller requested
-        #   headroom     = (1 - fraction) * T      — safety reserve to stay below
-        #   physical_cap = A_us + F - headroom     — max we can hold without spill
-        #   cap          = max(min(user_cap, physical_cap), A_us)
-        #                  (never below current usage — would cause instant OOM)
         headroom_b = int((1.0 - fraction) * total_b)
         user_cap_b = int(fraction * total_b)
         physical_cap_b = us_b + free_b - headroom_b
@@ -288,31 +259,90 @@ def set_vram_limit(fraction: float = 0.90) -> bool:
         cap_b = max(cap_b, us_b)  # cannot shrink below what we already hold
 
         effective_fraction = (cap_b / total_b) if total_b > 0 else fraction
-        # Clamp: never below 5% (absolute minimum for any allocation to work),
-        # never above the caller-requested fraction.
         effective_fraction = max(0.05, min(effective_fraction, fraction))
 
-        free_gb = free_b / 1024**3
-        us_gb = us_b / 1024**3
-        other_gb = other_b / 1024**3
-        headroom_gb = headroom_b / 1024**3
+        return (
+            effective_fraction,
+            int(cap_b),
+            free_b / 1024**3,
+            us_b / 1024**3,
+            other_b / 1024**3,
+            headroom_b / 1024**3,
+        )
+    except (RuntimeError, ValueError, AssertionError, TypeError):
+        return None
 
-        if physical_cap_b < us_b:
-            # GPU is under heavy external pressure; we cannot honor the requested
-            # headroom — warn so the user knows the cap was forced up.
-            logger.warning(
-                f"[VRAM_LIMIT] Cannot honor requested headroom — GPU under external "
-                f"pressure. Requested={fraction:.0%}, effective={effective_fraction:.0%} "
-                f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
-                f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
-            )
-        else:
-            logger.info(
-                f"[VRAM_LIMIT] Requested={fraction:.0%}, effective={effective_fraction:.0%} "
-                f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
-                f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
-            )
 
+def set_vram_limit(fraction: float = 0.90) -> bool:
+    """Set hard VRAM limit on the PyTorch CUDA allocator to prevent spillover.
+
+    On Windows, the NVIDIA driver preemptively evicts to shared memory when
+    VRAM approaches capacity. This hard limit prevents that by raising OOM
+    errors instead of spilling (which is much faster than slow spillover).
+
+    The effective fraction is computed by ``compute_effective_vram_cap`` from
+    live ``mem_get_info`` readings so that memory held by other processes
+    (browser, games, other ML jobs) is subtracted from our budget.
+
+    It is safe and expected to call this function multiple times; each call
+    re-measures the system state and re-applies the cap.
+
+    **Note on `allow_ram_fallback`**: when True in config, this function
+    returns without applying any cap — the PyTorch allocator is uncapped and
+    the OS may spill to shared RAM.  The flag does *not* affect the ORT
+    ``gpu_mem_limit`` cap (set in ``embeddings/onnx_loader.py``), which is
+    always-on when ``onnx_gpu_mem_limit=true``.
+
+    **ORT / FAISS**: ``set_per_process_memory_fraction`` only governs the
+    PyTorch CUDA allocator.  ORT's ``CUDAExecutionProvider`` and FAISS GPU
+    indexes use their own allocators and are not constrained here.
+
+    Args:
+        fraction: Requested fraction of dedicated VRAM (default: 0.90 = 90%).
+            The *effective* fraction may be lower when other processes hold VRAM.
+            Recommended: 0.80–0.90 depending on GPU headroom needs.
+
+    Returns:
+        True if limit was set (or skipped due to allow_ram_fallback), else False.
+    """
+    if not torch or not torch.cuda.is_available():
+        return False
+
+    # Check if RAM fallback is allowed — if so, skip the PyTorch cap only.
+    try:
+        config = _get_config_via_service_locator()
+        if config and config.performance.allow_ram_fallback:
+            logging.getLogger(__name__).info(
+                "[VRAM_LIMIT] RAM fallback allowed - skipping PyTorch VRAM cap"
+            )
+            return True  # Don't set limit, allow PyTorch spillover
+    except Exception as e:
+        logging.getLogger(__name__).debug(f"Config not available, using defaults: {e}")
+
+    logger = logging.getLogger(__name__)
+    result = compute_effective_vram_cap(fraction)
+    if result is None:
+        logger.warning("[VRAM_LIMIT] Failed to measure VRAM state — cap not applied")
+        return False
+
+    effective_fraction, cap_b, free_gb, us_gb, other_gb, headroom_gb = result
+
+    # Warn when free memory is below the requested headroom (external GPU pressure).
+    if free_gb < headroom_gb:
+        logger.warning(
+            f"[VRAM_LIMIT] Cannot honor requested headroom — GPU under external "
+            f"pressure. Requested={fraction:.0%}, effective={effective_fraction:.0%} "
+            f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
+            f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
+        )
+    else:
+        logger.info(
+            f"[VRAM_LIMIT] Requested={fraction:.0%}, effective={effective_fraction:.0%} "
+            f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
+            f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
+        )
+
+    try:
         torch.cuda.set_per_process_memory_fraction(effective_fraction, device=0)
         return True
     except (RuntimeError, ValueError, AssertionError, TypeError) as e:

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -219,18 +219,34 @@ def set_vram_limit(fraction: float = 0.90) -> bool:
     VRAM approaches capacity. This hard limit prevents that by raising OOM
     errors instead of spilling (which is much faster than slow spillover).
 
+    The effective fraction is computed dynamically from current free/allocated
+    VRAM so that memory held by other processes (browser, games, other ML jobs)
+    is subtracted from our budget.  This prevents the process cap from being set
+    above the physically available headroom, which would otherwise let our
+    allocations overcommit and trigger WDDM shared-memory spillover on Windows.
+
+    It is safe and expected to call this function multiple times (e.g., at init
+    and again before each embedding run); each call re-measures the system state
+    and re-applies the cap.
+
     If allow_ram_fallback is True in config, skip setting the limit to allow
     slower but more reliable spillover to system RAM.
 
     Args:
-        fraction: Fraction of dedicated VRAM to use (default: 0.90 = 90%)
-                  Recommended: 0.85-0.95 depending on GPU headroom needs
+        fraction: Requested fraction of dedicated VRAM (default: 0.90 = 90%).
+            The *effective* fraction may be lower when other processes hold VRAM.
+            Recommended: 0.80-0.90 depending on GPU headroom needs.
 
     Returns:
-        True if limit was set successfully, False otherwise
+        True if limit was set successfully, False otherwise.
 
     Note:
-        Should be called early, before heavy CUDA allocations.
+        - Safe to call multiple times; re-application is idempotent.
+        - On ONNX models, the cap only constrains PyTorch operations.
+          ORT's CUDAExecutionProvider allocates memory outside PyTorch and
+          is not governed by this limit.
+        - FAISS GPU indexes use their own CUDA allocator and are also not
+          constrained by set_per_process_memory_fraction.
     """
     if not torch or not torch.cuda.is_available():
         return False
@@ -246,14 +262,61 @@ def set_vram_limit(fraction: float = 0.90) -> bool:
     except Exception as e:
         logging.getLogger(__name__).debug(f"Config not available, using defaults: {e}")
 
+    logger = logging.getLogger(__name__)
     try:
-        torch.cuda.set_per_process_memory_fraction(fraction, device=0)
-        logging.getLogger(__name__).info(
-            f"[VRAM_LIMIT] Set hard limit to {fraction:.0%} of dedicated VRAM"
-        )
+        # Measure current VRAM state so the effective cap accounts for memory
+        # already held by other processes.
+        #   T = total device VRAM
+        #   F = system-wide free VRAM (excludes ALL processes)
+        #   A_us = bytes our PyTorch process currently holds
+        #   A_other = bytes held by every other process
+        free_b, total_b = torch.cuda.mem_get_info(0)
+        us_b = torch.cuda.memory_allocated(0)
+        other_b = max(0, total_b - free_b - us_b)
+
+        # Formula (see docs for derivation):
+        #   user_cap     = fraction * T            — what the caller requested
+        #   headroom     = (1 - fraction) * T      — safety reserve to stay below
+        #   physical_cap = A_us + F - headroom     — max we can hold without spill
+        #   cap          = max(min(user_cap, physical_cap), A_us)
+        #                  (never below current usage — would cause instant OOM)
+        headroom_b = int((1.0 - fraction) * total_b)
+        user_cap_b = int(fraction * total_b)
+        physical_cap_b = us_b + free_b - headroom_b
+
+        cap_b = min(user_cap_b, physical_cap_b)
+        cap_b = max(cap_b, us_b)  # cannot shrink below what we already hold
+
+        effective_fraction = (cap_b / total_b) if total_b > 0 else fraction
+        # Clamp: never below 5% (absolute minimum for any allocation to work),
+        # never above the caller-requested fraction.
+        effective_fraction = max(0.05, min(effective_fraction, fraction))
+
+        free_gb = free_b / 1024**3
+        us_gb = us_b / 1024**3
+        other_gb = other_b / 1024**3
+        headroom_gb = headroom_b / 1024**3
+
+        if physical_cap_b < us_b:
+            # GPU is under heavy external pressure; we cannot honor the requested
+            # headroom — warn so the user knows the cap was forced up.
+            logger.warning(
+                f"[VRAM_LIMIT] Cannot honor requested headroom — GPU under external "
+                f"pressure. Requested={fraction:.0%}, effective={effective_fraction:.0%} "
+                f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
+                f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
+            )
+        else:
+            logger.info(
+                f"[VRAM_LIMIT] Requested={fraction:.0%}, effective={effective_fraction:.0%} "
+                f"(free={free_gb:.1f}GB, us={us_gb:.1f}GB, "
+                f"other={other_gb:.1f}GB, headroom={headroom_gb:.1f}GB)"
+            )
+
+        torch.cuda.set_per_process_memory_fraction(effective_fraction, device=0)
         return True
     except (RuntimeError, ValueError, AssertionError, TypeError) as e:
-        logging.getLogger(__name__).warning(f"[VRAM_LIMIT] Failed to set: {e}")
+        logger.warning(f"[VRAM_LIMIT] Failed to set: {e}")
         return False
 
 
@@ -933,6 +996,16 @@ class CodeEmbedder:
 
         # Log VRAM usage after model load
         self._log_vram_usage("MODEL_LOADED")
+
+        # Re-apply VRAM cap with fresh memory readings — other processes may have
+        # allocated VRAM since CodeEmbedder.__init__, which would otherwise let us
+        # overcommit and trigger Windows WDDM shared-memory spillover.
+        try:
+            _embed_cfg = _get_config_via_service_locator()
+            if _embed_cfg and _embed_cfg.performance:
+                set_vram_limit(_embed_cfg.performance.vram_limit_fraction)
+        except (RuntimeError, AttributeError):
+            pass  # keep the __init__-time cap on failure
 
         # Load batch size from config if not explicitly provided
         if batch_size is None:

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -358,6 +358,7 @@ def calculate_optimal_batch_size(
     model_vram_gb: float = 0.0,
     model_name: str | None = None,
     activation_gb_per_item: float = 0.0,
+    ort_cap_gb: float = 0.0,
 ) -> int:
     """Calculate optimal batch size from architecture-derived activation memory cost.
 
@@ -401,6 +402,15 @@ def calculate_optimal_batch_size(
         # Use free memory — model weights are already loaded so they're excluded
         available_gb = free_gb
 
+        # For ONNX backend: constrain to the ORT arena's remaining activation budget.
+        # ORT's CUDAExecutionProvider has a hard gpu_mem_limit; the model weights
+        # already consume model_vram_gb of that cap.  Using system-wide free_gb
+        # would overestimate — ORT cannot exceed its cap regardless of system free.
+        if ort_cap_gb > 0.0:
+            ort_remaining_gb = max(0.0, ort_cap_gb - model_vram_gb)
+            if ort_remaining_gb < available_gb:
+                available_gb = ort_remaining_gb
+
         # Apply fragmentation factor: PyTorch caching allocator reserves ~18% extra
         # Validated from OOM analysis: 2.67GB fragmentation / 14.74GB allocated = 18%
         target_activation_gb = available_gb * memory_fraction * FRAGMENTATION_OVERHEAD
@@ -429,9 +439,14 @@ def calculate_optimal_batch_size(
         result = max(min_batch, min(optimal_batch, max_batch))
 
         logger = logging.getLogger(__name__)
+        ort_info = (
+            f", ORT cap: {ort_cap_gb:.1f}GB → remaining: {max(0.0, ort_cap_gb - model_vram_gb):.1f}GB"
+            if ort_cap_gb > 0.0
+            else ""
+        )
         logger.info(
             f"[DYNAMIC_BATCH] GPU: {free_gb:.1f}GB free / {total_gb:.1f}GB total, "
-            f"model: {model_vram_gb:.1f}GB ({model_name or 'unknown'}), "
+            f"model: {model_vram_gb:.1f}GB ({model_name or 'unknown'}){ort_info}, "
             f"available: {available_gb:.1f}GB → "
             f"target: {target_activation_gb:.1f}GB "
             f"({memory_fraction:.0%} × {FRAGMENTATION_OVERHEAD:.0%} frag), "
@@ -1102,6 +1117,20 @@ class CodeEmbedder:
                     0.05, min(memory_fraction, 0.95)
                 )  # Clamp to safe range
 
+                # For ONNX backend: tell the batch sizer about the ORT arena cap so
+                # it uses ORT-remaining budget (cap − model_weights) as available_gb
+                # instead of system-wide free memory (which ORT cannot fully use).
+                ort_cap_gb = 0.0
+                if hasattr(self._model, "ort_model"):
+                    try:
+                        _cap_result = compute_effective_vram_cap(
+                            config.performance.vram_limit_fraction
+                        )
+                        if _cap_result is not None:
+                            ort_cap_gb = _cap_result[1] / 1024**3  # bytes → GB
+                    except Exception:
+                        pass
+
                 batch_size = calculate_optimal_batch_size(
                     embedding_dim=config.embedding.dimension,
                     min_batch=config.performance.dynamic_batch_min,
@@ -1110,6 +1139,7 @@ class CodeEmbedder:
                     model_vram_gb=model_vram_gb,
                     model_name=self.model_name,
                     activation_gb_per_item=activation_gb_per_item,
+                    ort_cap_gb=ort_cap_gb,
                 )
                 self._logger.info(
                     f"Using dynamic GPU-optimized batch size {batch_size} for {len(chunks)} chunks"
@@ -1126,7 +1156,9 @@ class CodeEmbedder:
 
         # Process in batches for efficiency with progress bar
         console = Console(force_terminal=True)
-        total_batches = (len(chunks) + batch_size - 1) // batch_size
+        # current_batch_size tracks the live batch size — may be halved on OOM.
+        current_batch_size = batch_size
+        total_batches = (len(chunks) + current_batch_size - 1) // current_batch_size
 
         # Suppress INFO logs during progress bar to prevent line mixing
         original_log_level = self._logger.level
@@ -1142,9 +1174,11 @@ class CodeEmbedder:
             transient=False,
         ) as progress:
             task = progress.add_task("Embedding...", total=total_batches)
-            for i in range(0, len(chunks), batch_size):
-                batch = chunks[i : i + batch_size]
-                batch_num = (i // batch_size) + 1
+            i = 0
+            batch_num = 0
+            while i < len(chunks):
+                batch = chunks[i : i + current_batch_size]
+                batch_num += 1
 
                 # Log VRAM before batch
                 self._log_vram_usage("BATCH_START", batch_num)
@@ -1186,58 +1220,48 @@ class CodeEmbedder:
                         convert_to_tensor=use_tensor,
                         device=self.device if use_tensor else None,
                     )
-                except (RuntimeError, torch.cuda.OutOfMemoryError) as e:
-                    # OOM recovery: Clear cache, halve batch, retry
-                    if "out of memory" in str(e).lower():
-                        half_batch_size = len(batch_contents) // 2
-                        if half_batch_size < 1:
-                            self._logger.error(
-                                "[OOM_RECOVERY] Cannot reduce batch further, re-raising OOM"
-                            )
-                            raise  # Can't reduce further
-
-                        self._logger.warning(
-                            f"[OOM_RECOVERY] CUDA OOM detected! "
-                            f"Reducing batch from {len(batch_contents)} to {half_batch_size}, "
-                            f"clearing cache, and retrying..."
+                except RuntimeError as e:
+                    # OOM recovery: halve current_batch_size and retry the same chunk
+                    # position with a smaller batch.  Applies to both PyTorch CUDA OOM
+                    # (torch.cuda.OutOfMemoryError subclasses RuntimeError) and ORT BFCArena OOM
+                    # ("BFCArena::AllocateRawInternal Available memory … smaller than requested").
+                    err_str = str(e).lower()
+                    is_oom = (
+                        "out of memory" in err_str
+                        or "bfcarena" in err_str
+                        or (
+                            "available memory" in err_str
+                            and "smaller than requested" in err_str
                         )
-
-                        # Clear GPU cache and Python garbage
+                    )
+                    if is_oom and current_batch_size > 1:
+                        new_size = max(1, current_batch_size // 2)
+                        self._logger.warning(
+                            f"[OOM_RECOVERY] OOM at batch_size={current_batch_size} "
+                            f"({type(e).__name__}) — halving to {new_size}. "
+                            f"All subsequent batches will use size {new_size}."
+                        )
+                        current_batch_size = new_size
+                        # Recalculate progress-bar total for the remaining smaller batches
+                        completed = int(progress.tasks[task].completed)
+                        remaining_chunks = len(chunks) - i
+                        remaining_batches = (
+                            remaining_chunks + current_batch_size - 1
+                        ) // current_batch_size
+                        progress.update(task, total=completed + remaining_batches)
+                        # Flush GPU caches before retry
                         if torch and torch.cuda.is_available():
                             torch.cuda.empty_cache()
                         gc.collect()
-
-                        # Split batch in half and process each half
-                        half1 = batch_contents[:half_batch_size]
-                        half2 = batch_contents[half_batch_size:]
-
-                        # Process first half
-                        emb1 = self.model.encode(
-                            half1,
-                            show_progress_bar=False,
-                            convert_to_tensor=use_tensor,
-                            device=self.device if use_tensor else None,
-                        )
-
-                        # Process second half
-                        emb2 = self.model.encode(
-                            half2,
-                            show_progress_bar=False,
-                            convert_to_tensor=use_tensor,
-                            device=self.device if use_tensor else None,
-                        )
-
-                        # Combine results
-                        if torch and torch.is_tensor(emb1):
-                            batch_embeddings = torch.cat([emb1, emb2], dim=0)
-                        else:
-                            batch_embeddings = np.vstack([emb1, emb2])
-
-                        self._logger.info(
-                            "[OOM_RECOVERY] Successfully recovered from OOM by splitting batch"
-                        )
+                        batch_num -= 1  # this attempt is retried, don't advance counter
+                        continue  # retry the same i with the smaller batch size
                     else:
-                        raise  # Different error, re-raise
+                        if is_oom:
+                            self._logger.error(
+                                f"[OOM_RECOVERY] Cannot reduce batch further "
+                                f"(current_batch_size={current_batch_size}), re-raising OOM"
+                            )
+                        raise
 
                 # Convert back to numpy for consistency with rest of codebase
                 # Note: bf16 tensors must be converted to float32 first (numpy doesn't support bf16)
@@ -1309,7 +1333,8 @@ class CodeEmbedder:
                 # Log VRAM after batch
                 self._log_vram_usage("BATCH_END", batch_num)
 
-                # Update progress bar
+                # Advance to next chunk position and update progress bar
+                i += current_batch_size
                 progress.update(task, advance=1)
 
         # Restore original log level

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -301,6 +301,61 @@ class ONNXModelLoader:
                         exc_info=True,
                     )
 
+            # Constrain ORT's own CUDA arena allocator so it cannot push the GPU
+            # into WDDM shared-memory spillover on Windows.
+            # Unlike PyTorch's set_per_process_memory_fraction (which ORT ignores),
+            # gpu_mem_limit is respected by the CUDAExecutionProvider arena.
+            # Uses the same effective-cap formula as set_vram_limit() so both
+            # backends share the same budget.  Not applied for CPUExecutionProvider.
+            provider_options = None
+            if provider == "CUDAExecutionProvider":
+                try:
+                    from embeddings.embedder import compute_effective_vram_cap
+                    from mcp_server.utils.config_helpers import (
+                        get_config_via_service_locator as _get_cfg,
+                    )
+
+                    _cfg = _get_cfg()
+                    _fraction = (
+                        _cfg.performance.vram_limit_fraction
+                        if _cfg and _cfg.performance
+                        else 0.80
+                    )
+                    _onnx_cap_enabled = (
+                        _cfg.performance.onnx_gpu_mem_limit
+                        if _cfg and _cfg.performance
+                        else True
+                    )
+                    if _onnx_cap_enabled:
+                        _cap_result = compute_effective_vram_cap(_fraction)
+                        if _cap_result is not None:
+                            (
+                                _,
+                                _cap_bytes,
+                                _free_gb,
+                                _us_gb,
+                                _other_gb,
+                                _headroom_gb,
+                            ) = _cap_result
+                            provider_options = [
+                                {
+                                    "gpu_mem_limit": int(_cap_bytes),
+                                    "arena_extend_strategy": "kSameAsRequested",
+                                }
+                            ]
+                            _log.info(
+                                f"[ONNX_VRAM] gpu_mem_limit={_cap_bytes / 1024**3:.2f}GB, "
+                                f"arena=kSameAsRequested "
+                                f"(free={_free_gb:.1f}GB, us={_us_gb:.1f}GB, "
+                                f"other={_other_gb:.1f}GB, headroom={_headroom_gb:.1f}GB)"
+                            )
+                        else:
+                            _log.debug(
+                                "[ONNX_VRAM] CUDA not available — gpu_mem_limit not set"
+                            )
+                except Exception as _e:
+                    _log.debug(f"[ONNX_VRAM] Could not compute cap (non-fatal): {_e}")
+
             # Suppress benign "incorrect regex pattern" warning from transformers.
             # BGE-M3 uses a Mistral-derived tokenizer that triggers this via logger.warning()
             # (not warnings.warn), so we must temporarily raise the transformers log level.
@@ -313,6 +368,7 @@ class ONNXModelLoader:
                     file_name=model_file,
                     provider=provider,
                     session_options=session_options,
+                    provider_options=provider_options,
                 )
                 try:
                     tokenizer = AutoTokenizer.from_pretrained(str(self._onnx_dir))

--- a/search/config.py
+++ b/search/config.py
@@ -234,6 +234,12 @@ class PerformanceConfig:
     use_onnx: bool = (
         False  # When True, loads eligible models via ORTModelForFeatureExtraction
     )
+    onnx_gpu_mem_limit: bool = (
+        True  # Constrain ORT CUDAExecutionProvider arena via gpu_mem_limit.
+        # Uses the same effective-cap formula as set_vram_limit() so the ONNX
+        # session cannot push the GPU into WDDM shared-memory spillover.
+        # Disable only for debugging (raises OOM instead of spilling if too tight).
+    )
 
     # Auto-reindexing
     enable_auto_reindex: bool = True
@@ -533,6 +539,7 @@ class SearchConfig:
                 "enable_auto_reindex": self.performance.enable_auto_reindex,
                 "max_index_age_minutes": self.performance.max_index_age_minutes,
                 "use_onnx": self.performance.use_onnx,
+                "onnx_gpu_mem_limit": self.performance.onnx_gpu_mem_limit,
             },
             "multi_hop": {
                 "enabled": self.multi_hop.enabled,
@@ -711,6 +718,7 @@ class SearchConfig:
                     "max_index_age_minutes", 5.0
                 ),
                 use_onnx=performance_data.get("use_onnx", False),
+                onnx_gpu_mem_limit=performance_data.get("onnx_gpu_mem_limit", True),
             )
 
             multi_hop = MultiHopConfig(
@@ -881,6 +889,7 @@ class SearchConfig:
                 enable_auto_reindex=data.get("enable_auto_reindex", True),
                 max_index_age_minutes=data.get("max_index_age_minutes", 5.0),
                 use_onnx=data.get("use_onnx", False),
+                onnx_gpu_mem_limit=data.get("onnx_gpu_mem_limit", True),
             )
 
             multi_hop = MultiHopConfig(

--- a/search/neural_reranker.py
+++ b/search/neural_reranker.py
@@ -105,6 +105,15 @@ class NeuralReranker:
             CrossEncoder: Loaded model instance
         """
         if self._model is None:
+            # Re-apply VRAM cap before loading reranker weights — embedder and
+            # other processes may have changed free VRAM since server startup.
+            try:
+                from embeddings.embedder import set_vram_limit
+                from search.config import get_search_config as _gsc
+
+                set_vram_limit(_gsc().performance.vram_limit_fraction)
+            except Exception:
+                pass  # non-fatal — fall through to load
             self._logger.info(f"Loading reranker model: {self.model_name}")
             from sentence_transformers import CrossEncoder
 
@@ -243,6 +252,14 @@ class GenerativeReranker:
     def _ensure_loaded(self) -> None:
         """Lazy load model and tokenizer on first access."""
         if self._model is None:
+            # Re-apply VRAM cap before loading generative reranker weights.
+            try:
+                from embeddings.embedder import set_vram_limit
+                from search.config import get_search_config as _gsc
+
+                set_vram_limit(_gsc().performance.vram_limit_fraction)
+            except Exception:
+                pass  # non-fatal — fall through to load
             self._logger.info(f"Loading generative reranker: {self.model_name}")
             from transformers import AutoModelForCausalLM, AutoTokenizer
 
@@ -474,6 +491,14 @@ class JinaRerankerV3:
 
     def _load_or_fetch(self) -> None:
         """Internal: load model from cache or HuggingFace. Called under _load_lock."""
+        # Re-apply VRAM cap before loading Jina reranker weights.
+        try:
+            from embeddings.embedder import set_vram_limit
+            from search.config import get_search_config as _gsc
+
+            set_vram_limit(_gsc().performance.vram_limit_fraction)
+        except Exception:
+            pass  # non-fatal — fall through to load
         import transformers as _tf
         from huggingface_hub import try_to_load_from_cache
         from transformers import AutoConfig, AutoModel

--- a/search_config.json
+++ b/search_config.json
@@ -1,7 +1,7 @@
 {
   "embedding": {
-    "model_name": "Alibaba-NLP/gte-modernbert-base",
-    "dimension": 768,
+    "model_name": "BAAI/bge-m3",
+    "dimension": 1024,
     "batch_size": 128,
     "query_cache_size": 128,
     "enable_import_context": true,
@@ -32,7 +32,7 @@
     "enable_entity_tracking": true,
     "prefer_gpu": true,
     "vram_limit_fraction": 0.8,
-    "allow_ram_fallback": true,
+    "allow_ram_fallback": false,
     "enable_fp16": true,
     "prefer_bf16": true,
     "enable_dynamic_batch_size": true,

--- a/search_config.json
+++ b/search_config.json
@@ -32,7 +32,7 @@
     "enable_entity_tracking": true,
     "prefer_gpu": true,
     "vram_limit_fraction": 0.8,
-    "allow_ram_fallback": false,
+    "allow_ram_fallback": true,
     "enable_fp16": true,
     "prefer_bf16": true,
     "enable_dynamic_batch_size": true,
@@ -40,7 +40,8 @@
     "dynamic_batch_max": 64,
     "enable_auto_reindex": true,
     "max_index_age_minutes": 30.0,
-    "use_onnx": true
+    "use_onnx": true,
+    "onnx_gpu_mem_limit": true
   },
   "multi_hop": {
     "enabled": true,

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -844,6 +844,192 @@ class TestCheckVramStatus:
         assert should_abort is False
 
 
+class TestSetVramLimitEffective:
+    """Tests for set_vram_limit() effective-fraction computation.
+
+    Verifies that the VRAM cap accounts for memory already held by other
+    processes, preventing Windows WDDM shared-memory spillover when external
+    GPU allocations are present at call time.
+    """
+
+    # Helpers to build mock torch with configurable mem_get_info / memory_allocated
+    @staticmethod
+    def _make_torch(free_gb: float, total_gb: float, us_gb: float = 0.0):
+        """Return a MagicMock that mimics torch with the given VRAM readings."""
+        m = MagicMock()
+        m.cuda.is_available.return_value = True
+        m.cuda.mem_get_info.return_value = (
+            int(free_gb * 1024**3),
+            int(total_gb * 1024**3),
+        )
+        m.cuda.memory_allocated.return_value = int(us_gb * 1024**3)
+        return m
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_no_external_pressure(self, mock_torch, mock_cfg):
+        """GPU is idle: effective fraction equals the requested fraction."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(24 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = 0
+        mock_cfg.return_value = None  # no config → skip allow_ram_fallback check
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+
+        assert result is True
+        mock_torch.cuda.set_per_process_memory_fraction.assert_called_once()
+        eff = mock_torch.cuda.set_per_process_memory_fraction.call_args[0][0]
+        # With no external pressure physical_cap == user_cap → effective == r
+        assert 0.79 <= eff <= 0.81, f"expected ~0.80, got {eff:.4f}"
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_other_process_holds_10gb_bug_scenario(self, mock_torch, mock_cfg):
+        """Bug scenario: other process holds 10 GB on a 24 GB GPU.
+
+        Expected: effective fraction is reduced so our process + other ≤ 19.2 GB.
+        """
+        mock_torch.cuda.is_available.return_value = True
+        # free=14 GB, total=24 GB, we hold 0 → other = 10 GB
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(14 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = 0
+        mock_cfg.return_value = None
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+
+        assert result is True
+        mock_torch.cuda.set_per_process_memory_fraction.assert_called_once()
+        eff = mock_torch.cuda.set_per_process_memory_fraction.call_args[0][0]
+        # physical_cap = 0 + 14 - 4.8 = 9.2 GB → 9.2/24 ≈ 0.383
+        assert 0.36 <= eff <= 0.40, f"expected ~0.383, got {eff:.4f}"
+        # Verify total physical demand at saturation doesn't exceed 24 GB
+        cap_gb = eff * 24
+        assert cap_gb + 10 <= 24.05, f"Would spill: cap={cap_gb:.1f} + other=10 > 24 GB"
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_reapplication_mid_run(self, mock_torch, mock_cfg):
+        """Re-application while our process already holds 6 GB, others hold 4 GB."""
+        mock_torch.cuda.is_available.return_value = True
+        # free=14 GB, total=24 GB, us=6 GB → other=4 GB
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(14 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = int(6 * 1024**3)
+        mock_cfg.return_value = None
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+
+        assert result is True
+        eff = mock_torch.cuda.set_per_process_memory_fraction.call_args[0][0]
+        # physical_cap = 6 + 14 - 4.8 = 15.2 GB → 15.2/24 ≈ 0.633
+        assert 0.61 <= eff <= 0.65, f"expected ~0.633, got {eff:.4f}"
+        # Cap must not be below what we already hold
+        assert eff * 24 >= 6 - 0.1
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_clamp_when_physical_cap_below_current_usage(self, mock_torch, mock_cfg):
+        """GPU under heavy external pressure: cap is forced up to us_b, warning logged."""
+        mock_torch.cuda.is_available.return_value = True
+        # free=2 GB, total=24 GB, us=12 GB → other=10 GB
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(2 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = int(12 * 1024**3)
+        mock_cfg.return_value = None
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+
+        assert result is True
+        eff = mock_torch.cuda.set_per_process_memory_fraction.call_args[0][0]
+        # physical_cap = 12+2-4.8 = 9.2 < us=12 → clamped to us → eff = 12/24 = 0.5
+        assert 0.49 <= eff <= 0.51, f"expected ~0.50, got {eff:.4f}"
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_allow_ram_fallback_skips_limit(self, mock_torch, mock_cfg):
+        """When allow_ram_fallback=True, set_per_process_memory_fraction is NOT called."""
+        mock_torch.cuda.is_available.return_value = True
+        perf = MagicMock()
+        perf.allow_ram_fallback = True
+        cfg = MagicMock()
+        cfg.performance = perf
+        mock_cfg.return_value = cfg
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+
+        assert result is True
+        mock_torch.cuda.set_per_process_memory_fraction.assert_not_called()
+
+    @patch("embeddings.embedder.torch", None)
+    def test_no_cuda_returns_false(self):
+        """Returns False immediately when torch/CUDA is unavailable."""
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+        assert result is False
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_set_per_process_raises_returns_false(self, mock_torch, mock_cfg):
+        """Returns False and logs a warning when set_per_process_memory_fraction raises."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(20 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = 0
+        mock_torch.cuda.set_per_process_memory_fraction.side_effect = RuntimeError(
+            "CUDA error"
+        )
+        mock_cfg.return_value = None
+
+        from embeddings.embedder import set_vram_limit
+
+        result = set_vram_limit(0.8)
+        assert result is False
+
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    @patch("embeddings.embedder.torch")
+    def test_idempotent_same_inputs(self, mock_torch, mock_cfg):
+        """Two back-to-back calls with identical inputs produce the same effective fraction."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.mem_get_info.return_value = (
+            int(16 * 1024**3),
+            int(24 * 1024**3),
+        )
+        mock_torch.cuda.memory_allocated.return_value = 0
+        mock_cfg.return_value = None
+
+        from embeddings.embedder import set_vram_limit
+
+        set_vram_limit(0.8)
+        eff1 = mock_torch.cuda.set_per_process_memory_fraction.call_args_list[-1][0][0]
+        set_vram_limit(0.8)
+        eff2 = mock_torch.cuda.set_per_process_memory_fraction.call_args_list[-1][0][0]
+
+        assert abs(eff1 - eff2) < 1e-9
+
+
 class TestContextExtraction:
     """Test context extraction features (v0.8.0+) for import and class signatures."""
 

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -1030,6 +1030,103 @@ class TestSetVramLimitEffective:
         assert abs(eff1 - eff2) < 1e-9
 
 
+class TestComputeEffectiveVramCap:
+    """Tests for compute_effective_vram_cap() — the pure helper used by both
+    set_vram_limit (PyTorch cap) and onnx_loader (ORT gpu_mem_limit).
+    """
+
+    @patch("embeddings.embedder.torch")
+    def test_no_external_pressure_cap_equals_user_request(self, mock_torch):
+        """Idle GPU: cap_bytes ≈ fraction × total."""
+        mock_torch.cuda.is_available.return_value = True
+        total = int(24 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (total, total)
+        mock_torch.cuda.memory_allocated.return_value = 0
+
+        from embeddings.embedder import compute_effective_vram_cap
+
+        result = compute_effective_vram_cap(0.8)
+        assert result is not None
+        eff_frac, cap_bytes, free_gb, us_gb, other_gb, headroom_gb = result
+        # cap_bytes should be ≈ 0.80 × 24 GB
+        expected_bytes = int(0.8 * total)
+        assert abs(cap_bytes - expected_bytes) < 1024**2  # within 1 MB
+        assert 0.79 <= eff_frac <= 0.81
+
+    @patch("embeddings.embedder.torch")
+    def test_other_process_holds_10gb_reduces_cap(self, mock_torch):
+        """Bug scenario: other process holds 10 GB on 24 GB GPU.
+
+        physical_cap = 0 + 14 − 4.8 = 9.2 GB → cap_bytes ≈ 9.2 GB.
+        """
+        mock_torch.cuda.is_available.return_value = True
+        total = int(24 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (int(14 * 1024**3), total)
+        mock_torch.cuda.memory_allocated.return_value = 0
+
+        from embeddings.embedder import compute_effective_vram_cap
+
+        result = compute_effective_vram_cap(0.8)
+        assert result is not None
+        eff_frac, cap_bytes, free_gb, us_gb, other_gb, headroom_gb = result
+        cap_gb = cap_bytes / 1024**3
+        # physical_cap = 14 − 4.8 = 9.2 GB
+        assert 9.0 <= cap_gb <= 9.4, f"expected ~9.2 GB cap, got {cap_gb:.2f} GB"
+        assert 0.36 <= eff_frac <= 0.40
+        # Diagnostic fields
+        assert abs(free_gb - 14.0) < 0.1
+        assert abs(other_gb - 10.0) < 0.1
+        assert abs(headroom_gb - 4.8) < 0.1
+
+    @patch("embeddings.embedder.torch")
+    def test_reapplication_mid_run(self, mock_torch):
+        """Re-application while holding 6 GB, others hold 4 GB.
+
+        physical_cap = 6 + 14 − 4.8 = 15.2 GB.
+        """
+        mock_torch.cuda.is_available.return_value = True
+        total = int(24 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (int(14 * 1024**3), total)
+        mock_torch.cuda.memory_allocated.return_value = int(6 * 1024**3)
+
+        from embeddings.embedder import compute_effective_vram_cap
+
+        result = compute_effective_vram_cap(0.8)
+        assert result is not None
+        eff_frac, cap_bytes, free_gb, us_gb, other_gb, headroom_gb = result
+        cap_gb = cap_bytes / 1024**3
+        # physical_cap = 6 + 14 - 4.8 = 15.2 GB
+        assert 15.0 <= cap_gb <= 15.4, f"expected ~15.2 GB cap, got {cap_gb:.2f} GB"
+        # cap must never be below current us (6 GB)
+        assert cap_gb >= 5.9
+
+    @patch("embeddings.embedder.torch", None)
+    def test_no_cuda_returns_none(self):
+        """Returns None when torch is unavailable."""
+        from embeddings.embedder import compute_effective_vram_cap
+
+        assert compute_effective_vram_cap(0.8) is None
+
+    @patch("embeddings.embedder.torch")
+    def test_no_cuda_available_returns_none(self, mock_torch):
+        """Returns None when CUDA is not available."""
+        mock_torch.cuda.is_available.return_value = False
+
+        from embeddings.embedder import compute_effective_vram_cap
+
+        assert compute_effective_vram_cap(0.8) is None
+
+    @patch("embeddings.embedder.torch")
+    def test_mem_get_info_raises_returns_none(self, mock_torch):
+        """Returns None when GPU measurement fails."""
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.mem_get_info.side_effect = RuntimeError("CUDA error")
+
+        from embeddings.embedder import compute_effective_vram_cap
+
+        assert compute_effective_vram_cap(0.8) is None
+
+
 class TestContextExtraction:
     """Test context extraction features (v0.8.0+) for import and class signatures."""
 

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -1405,3 +1405,289 @@ class TestContextExtraction:
         assert "class TestClass:" not in embedding_content
         # But code content should still be present
         assert "def method(self):" in embedding_content
+
+
+class TestCalculateOptimalBatchSizeOrtCap:
+    """Tests for the ort_cap_gb parameter of calculate_optimal_batch_size().
+
+    Verifies that when an ORT arena cap is provided the batch sizer uses
+    ``min(free_gb, ort_cap - model_vram)`` as the available memory budget
+    rather than the full system-free figure.
+    """
+
+    @patch("embeddings.embedder.torch")
+    def test_ort_cap_constrains_available(self, mock_torch):
+        """ORT cap tighter than system free → available_gb clipped to cap remaining."""
+        from embeddings.embedder import calculate_optimal_batch_size
+
+        mock_torch.cuda.is_available.return_value = True
+        total_bytes = int(8 * 1024**3)
+        # System free after model load = 5.3 GB, but ORT cap was 5.0 GB and model
+        # already occupies 1.0 GB of that cap → ORT remaining = 4.0 GB.
+        mock_torch.cuda.mem_get_info.return_value = (int(5.3 * 1024**3), total_bytes)
+
+        # activation cost = 0.3 GB/item so batch without cap = floor(5.3*0.65*0.82/0.3)=9
+        # with ORT cap remaining = 4.0 GB: floor(4.0*0.65*0.82/0.3) = 7
+        result_without_cap = calculate_optimal_batch_size(
+            model_vram_gb=1.0,
+            activation_gb_per_item=0.3,
+            memory_fraction=0.65,
+            min_batch=1,
+            max_batch=64,
+        )
+        result_with_cap = calculate_optimal_batch_size(
+            model_vram_gb=1.0,
+            activation_gb_per_item=0.3,
+            memory_fraction=0.65,
+            min_batch=1,
+            max_batch=64,
+            ort_cap_gb=5.0,
+        )
+        assert result_with_cap < result_without_cap, (
+            f"ORT cap should lower batch size: with_cap={result_with_cap}, "
+            f"without_cap={result_without_cap}"
+        )
+
+    @patch("embeddings.embedder.torch")
+    def test_ort_cap_zero_leaves_behavior_unchanged(self, mock_torch):
+        """ort_cap_gb=0.0 (default) must not change available_gb."""
+        from embeddings.embedder import calculate_optimal_batch_size
+
+        mock_torch.cuda.is_available.return_value = True
+        total_bytes = int(24 * 1024**3)
+        mock_torch.cuda.mem_get_info.return_value = (int(16 * 1024**3), total_bytes)
+
+        r0 = calculate_optimal_batch_size(
+            model_vram_gb=2.0,
+            activation_gb_per_item=0.2,
+            memory_fraction=0.8,
+            min_batch=1,
+            max_batch=256,
+        )
+        r_explicit_zero = calculate_optimal_batch_size(
+            model_vram_gb=2.0,
+            activation_gb_per_item=0.2,
+            memory_fraction=0.8,
+            min_batch=1,
+            max_batch=256,
+            ort_cap_gb=0.0,
+        )
+        assert r0 == r_explicit_zero
+
+    @patch("embeddings.embedder.torch")
+    def test_ort_cap_larger_than_free_not_applied(self, mock_torch):
+        """ort_cap > system_free: cap is not the bottleneck, free_gb wins."""
+        from embeddings.embedder import calculate_optimal_batch_size
+
+        mock_torch.cuda.is_available.return_value = True
+        total_bytes = int(24 * 1024**3)
+        # free=4 GB, cap=20 GB → remaining=18 GB > 4 GB → free_gb is the limit
+        mock_torch.cuda.mem_get_info.return_value = (int(4 * 1024**3), total_bytes)
+
+        r_no_cap = calculate_optimal_batch_size(
+            model_vram_gb=2.0,
+            activation_gb_per_item=0.1,
+            memory_fraction=0.8,
+            min_batch=1,
+            max_batch=256,
+        )
+        r_large_cap = calculate_optimal_batch_size(
+            model_vram_gb=2.0,
+            activation_gb_per_item=0.1,
+            memory_fraction=0.8,
+            min_batch=1,
+            max_batch=256,
+            ort_cap_gb=20.0,
+        )
+        assert r_large_cap == r_no_cap
+
+
+class TestOomRecoveryBackoff:
+    """Tests for Fix B: OOM-recovery backoff in embed_chunks().
+
+    Verifies that BFCArena-style OOM errors (ORT) and classic CUDA OOM are
+    both caught, trigger batch-size halving, and allow the embedding run to
+    complete.  Uses a minimal fake model that raises on the first call and
+    succeeds on the second.
+    """
+
+    def _make_chunks(self, n: int):
+        """Return n minimal CodeChunk objects."""
+        chunks = []
+        for i in range(n):
+            c = MagicMock()
+            c.relative_path = Path(f"f{i}.py")
+            c.file_path = f"f{i}.py"
+            c.start_line = 1
+            c.end_line = 10
+            c.chunk_type = "function"
+            c.name = f"fn{i}"
+            c.parent_name = ""
+            c.parent_chunk_id = None
+            c.docstring = ""
+            c.decorators = []
+            c.imports = []
+            c.complexity_score = 1
+            c.tags = []
+            c.content = f"def fn{i}(): pass"
+            c.calls = []
+            c.relationships = []
+            chunks.append(c)
+        return chunks
+
+    @patch("embeddings.embedder.torch")
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    def test_bfcarena_oom_triggers_halve_and_retry(self, mock_get_cfg, mock_torch):
+        """BFCArena OOM → batch halved → all chunks embedded successfully."""
+        from embeddings.embedder import CodeEmbedder
+
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.is_tensor = MagicMock(return_value=False)
+
+        cfg = MagicMock()
+        cfg.performance.enable_dynamic_batch_size = False
+        cfg.performance.allow_ram_fallback = True
+        cfg.embedding.batch_size = 4
+        cfg.embedding.dimension = 768
+        mock_get_cfg.return_value = cfg
+
+        embedder = CodeEmbedder.__new__(CodeEmbedder)
+        embedder._logger = MagicMock()
+        embedder.model_name = "test/model"
+        embedder.device = "cpu"
+        embedder._query_cache = MagicMock()
+        embedder._model_vram_usage = {}
+        embedder._model_warmed_up = True
+        embedder._check_vram_status = MagicMock(return_value=(0.5, False, False))
+        embedder._log_vram_usage = MagicMock()
+        embedder._is_gpu_device = MagicMock(return_value=False)
+        embedder._get_model_config = MagicMock(return_value={"passage_prefix": ""})
+
+        call_count = 0
+
+        def fake_encode(texts, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError(
+                    "BFCArena::AllocateRawInternal Available memory of "
+                    "875860224 is smaller than requested bytes of 1338163200"
+                )
+            dim = 768
+            return np.zeros((len(texts), dim), dtype=np.float32)
+
+        fake_model = MagicMock()
+        fake_model.encode = fake_encode
+        embedder._model = fake_model
+        embedder.create_embedding_content = MagicMock(side_effect=lambda c: c.content)
+
+        chunks = self._make_chunks(4)
+        results = embedder.embed_chunks(chunks)
+
+        assert len(results) == 4
+        # Warning should have been logged about halving
+        warn_calls = [str(c) for c in embedder._logger.warning.call_args_list]
+        assert any("OOM_RECOVERY" in w for w in warn_calls)
+
+    @patch("embeddings.embedder.torch")
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    def test_classic_cuda_oom_still_caught(self, mock_get_cfg, mock_torch):
+        """Classic 'out of memory' RuntimeError is also caught and triggers halving."""
+        from embeddings.embedder import CodeEmbedder
+
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.is_tensor = MagicMock(return_value=False)
+
+        cfg = MagicMock()
+        cfg.performance.enable_dynamic_batch_size = False
+        cfg.performance.allow_ram_fallback = True
+        cfg.embedding.batch_size = 4
+        cfg.embedding.dimension = 768
+        mock_get_cfg.return_value = cfg
+
+        embedder = CodeEmbedder.__new__(CodeEmbedder)
+        embedder._logger = MagicMock()
+        embedder.model_name = "test/model"
+        embedder.device = "cpu"
+        embedder._query_cache = MagicMock()
+        embedder._model_vram_usage = {}
+        embedder._model_warmed_up = True
+        embedder._check_vram_status = MagicMock(return_value=(0.5, False, False))
+        embedder._log_vram_usage = MagicMock()
+        embedder._is_gpu_device = MagicMock(return_value=False)
+        embedder._get_model_config = MagicMock(return_value={"passage_prefix": ""})
+
+        call_count = 0
+
+        def fake_encode(texts, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("CUDA out of memory. Tried to allocate 2.00 GiB")
+            dim = 768
+            return np.zeros((len(texts), dim), dtype=np.float32)
+
+        fake_model = MagicMock()
+        fake_model.encode = fake_encode
+        embedder._model = fake_model
+        embedder.create_embedding_content = MagicMock(side_effect=lambda c: c.content)
+
+        chunks = self._make_chunks(4)
+        results = embedder.embed_chunks(chunks)
+
+        assert len(results) == 4
+
+    @patch("embeddings.embedder.torch")
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    def test_batch_size_reduced_persists_for_subsequent_batches(
+        self, mock_get_cfg, mock_torch
+    ):
+        """After OOM, the smaller batch_size is used for all remaining batches."""
+        from embeddings.embedder import CodeEmbedder
+
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.is_tensor = MagicMock(return_value=False)
+
+        cfg = MagicMock()
+        cfg.performance.enable_dynamic_batch_size = False
+        cfg.performance.allow_ram_fallback = True
+        cfg.embedding.batch_size = 4
+        cfg.embedding.dimension = 768
+        mock_get_cfg.return_value = cfg
+
+        embedder = CodeEmbedder.__new__(CodeEmbedder)
+        embedder._logger = MagicMock()
+        embedder.model_name = "test/model"
+        embedder.device = "cpu"
+        embedder._query_cache = MagicMock()
+        embedder._model_vram_usage = {}
+        embedder._model_warmed_up = True
+        embedder._check_vram_status = MagicMock(return_value=(0.5, False, False))
+        embedder._log_vram_usage = MagicMock()
+        embedder._is_gpu_device = MagicMock(return_value=False)
+        embedder._get_model_config = MagicMock(return_value={"passage_prefix": ""})
+
+        batch_sizes_seen = []
+
+        def fake_encode(texts, **kwargs):
+            batch_sizes_seen.append(len(texts))
+            if len(texts) >= 4:
+                raise RuntimeError(
+                    "BFCArena::AllocateRawInternal Available memory of "
+                    "100 is smaller than requested bytes of 200"
+                )
+            return np.zeros((len(texts), 768), dtype=np.float32)
+
+        fake_model = MagicMock()
+        fake_model.encode = fake_encode
+        embedder._model = fake_model
+        embedder.create_embedding_content = MagicMock(side_effect=lambda c: c.content)
+
+        # 8 chunks, initial batch=4 → OOM → halved to 2 → all 4 batches of 2
+        chunks = self._make_chunks(8)
+        results = embedder.embed_chunks(chunks)
+
+        assert len(results) == 8
+        # First call fails with batch=4, then all subsequent calls use batch=2
+        assert batch_sizes_seen[0] == 4  # the failing attempt
+        assert all(s == 2 for s in batch_sizes_seen[1:])  # all retries use 2

--- a/tests/unit/embeddings/test_onnx_loader.py
+++ b/tests/unit/embeddings/test_onnx_loader.py
@@ -424,3 +424,153 @@ class TestONNXModelLoaderLoad:
             pytest.raises(RuntimeError, match="Failed to load"),
         ):
             loader.load()
+
+
+# ---------------------------------------------------------------------------
+# ORT provider_options — gpu_mem_limit cap
+# ---------------------------------------------------------------------------
+
+
+class TestOrtProviderOptions:
+    """Verify that ONNXModelLoader.load() passes gpu_mem_limit to the ORT session
+    when CUDAExecutionProvider is used and onnx_gpu_mem_limit is enabled.
+
+    The cap logic uses lazy imports (inside the function body) to avoid circular
+    imports.  Patching must target the *source* module attributes, not the
+    onnx_loader namespace (since the names are resolved at call time via
+    ``from X import Y`` inside the function).
+    """
+
+    def _mock_ort(self):
+        mock_ort = MagicMock()
+        mock_ort.ORTModelForFeatureExtraction.from_pretrained.return_value = MagicMock()
+        return mock_ort
+
+    def _mock_tf(self):
+        mock_tf = MagicMock()
+        mock_tf.AutoTokenizer.from_pretrained.return_value = MagicMock()
+        return mock_tf
+
+    def _make_cfg(self, fraction=0.8, onnx_gpu_mem_limit=True):
+        perf = MagicMock()
+        perf.vram_limit_fraction = fraction
+        perf.onnx_gpu_mem_limit = onnx_gpu_mem_limit
+        cfg = MagicMock()
+        cfg.performance = perf
+        return cfg
+
+    def test_cuda_provider_passes_gpu_mem_limit(self, tmp_path):
+        """CUDAExecutionProvider with onnx_gpu_mem_limit=True gets gpu_mem_limit > 0."""
+        mock_ort = self._mock_ort()
+        mock_tf = self._mock_tf()
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cuda")
+
+        # Patch compute_effective_vram_cap to return a deterministic cap (6 GB).
+        # Must patch at the source module because the import is lazy (inside fn body).
+        _cap_bytes = int(6 * 1024**3)
+        _cap_result = (0.75, _cap_bytes, 8.0, 0.0, 0.5, 1.6)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+            patch(
+                "embeddings.embedder.compute_effective_vram_cap",
+                return_value=_cap_result,
+            ),
+            patch(
+                "mcp_server.utils.config_helpers.get_config_via_service_locator",
+                return_value=self._make_cfg(onnx_gpu_mem_limit=True),
+            ),
+        ):
+            loader.load()
+
+        call_kwargs = (
+            mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args.kwargs
+        )
+        assert "provider_options" in call_kwargs
+        po = call_kwargs["provider_options"]
+        assert po is not None
+        assert len(po) == 1
+        assert po[0]["gpu_mem_limit"] == _cap_bytes
+        assert po[0]["arena_extend_strategy"] == "kSameAsRequested"
+
+    def test_onnx_gpu_mem_limit_false_passes_none(self, tmp_path):
+        """When onnx_gpu_mem_limit=False, provider_options is None."""
+        mock_ort = self._mock_ort()
+        mock_tf = self._mock_tf()
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cuda")
+
+        _cap_result = (0.75, int(6 * 1024**3), 8.0, 0.0, 0.5, 1.6)
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+            patch(
+                "embeddings.embedder.compute_effective_vram_cap",
+                return_value=_cap_result,
+            ),
+            patch(
+                "mcp_server.utils.config_helpers.get_config_via_service_locator",
+                return_value=self._make_cfg(onnx_gpu_mem_limit=False),
+            ),
+        ):
+            loader.load()
+
+        call_kwargs = (
+            mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args.kwargs
+        )
+        assert call_kwargs.get("provider_options") is None
+
+    def test_cpu_provider_passes_none(self, tmp_path):
+        """CPUExecutionProvider never gets provider_options (no gpu_mem_limit concept)."""
+        mock_ort = self._mock_ort()
+        mock_tf = self._mock_tf()
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cpu")
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+        ):
+            loader.load()
+
+        call_kwargs = (
+            mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args.kwargs
+        )
+        assert call_kwargs.get("provider_options") is None
+
+    def test_cap_compute_failure_falls_back_to_none(self, tmp_path):
+        """If compute_effective_vram_cap returns None, provider_options is None (non-fatal)."""
+        mock_ort = self._mock_ort()
+        mock_tf = self._mock_tf()
+        loader = ONNXModelLoader("m", onnx_cache_dir=tmp_path, device="cuda")
+
+        with (
+            patch.dict(
+                "sys.modules",
+                {"optimum.onnxruntime": mock_ort, "transformers": mock_tf},
+            ),
+            patch("embeddings.onnx_loader._is_converted", return_value=True),
+            patch(
+                "embeddings.embedder.compute_effective_vram_cap",
+                return_value=None,
+            ),
+            patch(
+                "mcp_server.utils.config_helpers.get_config_via_service_locator",
+                return_value=self._make_cfg(onnx_gpu_mem_limit=True),
+            ),
+        ):
+            loader.load()  # must not raise
+
+        call_kwargs = (
+            mock_ort.ORTModelForFeatureExtraction.from_pretrained.call_args.kwargs
+        )
+        assert call_kwargs.get("provider_options") is None


### PR DESCRIPTION
## Summary

Fixes Windows WDDM shared-memory spillover end-to-end on 8 GB laptop GPUs:

- **Other-process VRAM accounting**: `set_vram_limit()` now subtracts VRAM held by other
  processes before applying the cap — previously the process cap was applied against total GPU
  memory, causing spillover when other apps occupied VRAM
- **ORT arena cap**: `CUDAExecutionProvider` constrained via `gpu_mem_limit` +
  `arena_extend_strategy="kSameAsRequested"` — critical, because
  `torch.cuda.set_per_process_memory_fraction` does not govern ORT's allocator
- **Fix A (ORT-aware batch sizing)**: `calculate_optimal_batch_size()` accepts `ort_cap_gb` and
  constrains `available_gb = min(free_gb, ort_cap_gb − model_vram_gb)` so dynamic batching
  respects the ORT session arena
- **Fix B (OOM backoff)**: `embed_chunks()` loop catches BFCArena/RuntimeError OOM, halves
  batch size, calls `empty_cache()`, and retries — no user-visible failure; reduced batch
  persists for subsequent batches

Live-validated on RTX 4060 Laptop: gte-modernbert 32→16, bge-m3 16→8 after OOM, 3120 chunks
in 143.80s, zero shared-memory spillover.

## Commits

- `a209849` fix: account for other-process VRAM allocation in hard limit to prevent WDDM spillover
- `457648b` fix: constrain ORT CUDAExecutionProvider arena to prevent WDDM VRAM spillover
- `7b90388` fix: ORT-aware batch sizing + BFCArena OOM recovery (fix B+A)
- `96bf08e` docs: update SESSION_LOG with ORT VRAM cap + OOM recovery session

## Test plan

- [ ] CI: ruff + pytest (1975/1975 passing locally)
- [ ] CI: Claude Code Review
- [ ] CI: Gemini Review
- [ ] Manual: 8 GB GPU under multi-process VRAM pressure → zero `[SHARED_MEM]` log lines

🤖 Stacked PR 4/4 — depends on PR #22