### PR TITLE
fix: CI review follow-ups (ONNX dedup, cuda:N gate, OOM isinstance, dtype-aware estimate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`handle_get_memory_status()` field rename**: GPU entries now expose `non_torch_gb` instead of `ort_untracked_gb`. The old name was misleading — the computed value is device-wide NVML usage minus per-process PyTorch allocations, which conflates other processes + drivers + ORT, not just ORT. Any external dashboard or monitor reading the old key will receive `None`
 
+### Security
+
+- **Transitive dependency patch upgrades** (4 CVEs fixed) — `pygments` 2.19.2 → 2.20.0 (CVE-2026-4539, ReDoS in `AdlLexer`), `pyjwt` 2.10.1 → 2.12.0 (CVE-2026-32597, missing `crit` header validation per RFC 7515), `python-multipart` 0.0.22 → 0.0.26 (CVE-2026-40347, DoS via large multipart preamble/epilogue), `requests` 2.32.5 → 2.33.0 (CVE-2026-25645, predictable tempfile name in `extract_zipped_paths()`)
+- **Orphan dependency cleanup** — uninstalled `cryptography` (no dependents after `authlib` was removed upstream; eliminated CVE-2026-34073 + CVE-2026-39892), `typer-slim` and `shellingham` (pulled in by unused `mcp[cli]`/`huggingface_hub[mcp]` extras). Venv dropped from 127 → 124 packages; open CVE count dropped from 8 → 2 (remaining: `sqlitedict` CVE-2024-35515 mitigated via JSON serialization in `metadata.py`; `transformers` CVE-2026-1839 blocked by `optimum-onnx <4.58.0` pin)
+- **pyproject.toml security-comments block refreshed** — stale `cryptography`/`authlib` references removed; new transitive-dep CVE fixes documented; last-audit date bumped to 2026-04-16
+
+### Tests
+
+- Unit test count: **1,987** (up from 1,985). Additions cover narrowed OOM string fallback propagation, ONNX `cuda:1` device parametrization, and key-rename assertions (`non_torch_gb` present, `ort_untracked_gb` absent)
+
 ---
 
 ## [0.10.0] - 2026-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.0] - 2026-04-16
+
+### Added
+
+- **ONNX Runtime backend** (`embeddings/onnx_loader.py`, `embeddings/onnx_wrapper.py`) — opt-in inference path (`performance.use_onnx`) that loads eligible models via `ORTModelForFeatureExtraction` with the `CUDAExecutionProvider`. Auto-converts HuggingFace models to ONNX on first use, caches under `~/.cache/huggingface/hub/onnx/`. Supported pooling strategies: `cls`, `mean` (declared via `onnx_pooling` in `MODEL_REGISTRY`). Backend selection is per-model via `_should_use_onnx()` in `embeddings/model_loader.py`
+- **ORT CUDA arena cap** (`performance.onnx_gpu_mem_limit`, default `true`) — constrains ORT's CUDAExecutionProvider memory arena via the `gpu_mem_limit` provider option, using the same effective VRAM cap as the PyTorch `set_per_process_memory_fraction()` path. Prevents WDDM shared-memory spillover on Windows when external processes (browsers, games) hold GPU memory. Check `[ONNX_VRAM]` log lines for the computed cap
+- **BFCArena OOM recovery** (`CodeEmbedder.embed_chunks`) — when ORT raises a `BFCArena` OOM, the embedder now halves the dynamic batch size and retries (same flow as PyTorch `torch.cuda.OutOfMemoryError`). Detection uses `isinstance(e, torch.cuda.OutOfMemoryError)` with a string fallback for ORT-specific errors (`"bfcarena"`, `"available memory" + "smaller than requested"`)
+- **`onnx_supported` registry flag** — opt-out field on `MODEL_REGISTRY` entries whose upstream pooling is not representable in `onnx_wrapper.py` (currently `cls` / `mean` only). Set on `BAAI/bge-code-v1` (`lasttoken`) to prevent silent semantic drift. Gate lives in `_should_use_onnx()`
+- **Per-model activation measurement** (`ModelLoader._measure_activation_per_item`) — Tier-1 runtime measurement of peak VRAM delta per batch item via PyTorch memory stats (torch path) or NVML snapshots (ONNX path). Feeds dynamic batch sizing and replaces hardcoded per-model constants for models without explicit floors
+
+### Changed
+
+- **Default embedding pool: lightweight-speed** — `search_config.json` ships with `routing.multi_model_pool: "lightweight-speed"` (`BAAI/bge-m3` + `Alibaba-NLP/gte-modernbert-base`) and `routing.default_model: "bge_m3"`. Targeted at 8 GB laptop GPUs with zero shared-memory spillover under the ORT cap. Existing users with Qwen3 + BGE-Code indexes must re-index when switching pools
+- **Default reranker: `Alibaba-NLP/gte-reranker-modernbert-base`** — replaces `BAAI/bge-reranker-v2-m3` in the default config. Lighter VRAM footprint, comparable quality on the SSCG benchmark
+- **dtype-aware activation estimate** (`estimate_activation_gb_from_config`) — reads `config.torch_dtype` and uses 4 bytes for fp32 / 2 bytes for fp16/bf16. Previously hardcoded 2 bytes; fp32 models (rare in embeddings) were 2× under-estimated
+- **ORT-aware activation floors** (`MODEL_ACTIVATION_COST_OVERRIDES_ONNX`) — empirically calibrated per-item floors for BGE-M3 (0.28 GB) and GTE-ModernBERT (0.25 GB) prevent Tier-1 warmup undercounting (single-op peaks that warmup batches miss) from causing OOM at real batch sizes
+- **`_measure_activation_per_item` accepts `cuda:N`** — previously the device gate only accepted bare `"cuda"`; `cuda:0`/`cuda:1` silently skipped measurement and fell through to lower tiers
+
+### Fixed
+
+- **Duplicated ORT provider-options block** (`embeddings/onnx_loader.py`) — two near-identical 54-line blocks computed the same `provider_options`; only the second reached `from_pretrained` because the first was reset to `None`. The dead block has been removed
+- **OOM type detection** (`CodeEmbedder.embed_chunks`) — replaces string-only `"out of memory"` substring check with `isinstance(e, torch.cuda.OutOfMemoryError)` + a dedicated ORT BFCArena string fallback. Non-OOM `RuntimeError`s now propagate correctly without triggering batch halving
+- **`validate()` docstring** (`tools/convert_onnx.py`) — previously claimed "max cosine diff < 0.001"; code computes `abs(pt - onnx).max()` on L2-normalised embeddings. Docstring updated to match
+- **Narrowed exception tuples** (`CodeEmbedder`) — `(RuntimeError, ValueError, AssertionError, TypeError)` → `(RuntimeError, ValueError, AssertionError)` on paths where `TypeError` would mask real bugs
+- **Silent excepts logged at DEBUG** — VRAM-cap re-apply and ORT-cap compute paths previously swallowed errors silently. Now emit a DEBUG log line with the exception type for diagnostics
+
+### Breaking changes
+
+- **`handle_get_memory_status()` field rename**: GPU entries now expose `non_torch_gb` instead of `ort_untracked_gb`. The old name was misleading — the computed value is device-wide NVML usage minus per-process PyTorch allocations, which conflates other processes + drivers + ORT, not just ORT. Any external dashboard or monitor reading the old key will receive `None`
+
+---
+
 ## [0.10.0] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 - **Centrality-Adaptive BM25 Boost**: High-centrality nodes (base classes, utilities) get BM25 score boost — compensates for single-vector ceiling (DeepMind LIMIT, ICLR 2026)
 - **File-Role Tagging**: Chunks tagged `role:src/test/doc/config` at index time — enables role-aware ranking and precision boosts
 
-**Status**: ✅ Production-ready | 1,985+ passing tests | All 19 MCP tools operational | Windows 10/11
+**Status**: ✅ Production-ready | 1,987+ passing tests | All 19 MCP tools operational | Windows 10/11
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,18 @@
 ## Highlights
 
 - **Hybrid Search**: BM25 + semantic fusion — on the [SSCG benchmark](#benchmark-results) (2026-04-10, 13 queries, k=10; cutoffs @5/@10): **Hit@5 100%, MRR 0.80, R@10 0.83 (best deep recall)** - [benchmarks](docs/BENCHMARKS.md)
-- **Neural Reranking**: Cross-encoder models (BGE-reranker-v2-m3 OR Jina-reranker-v2) improve ranking quality by 5-15% - [advanced features](docs/ADVANCED_FEATURES_GUIDE.md#neural-reranking-configuration)
+- **Neural Reranking**: Cross-encoder models (gte-reranker-modernbert-base OR BGE-reranker-v2-m3 OR Jina-reranker-v2) improve ranking quality by 5-15% - [advanced features](docs/ADVANCED_FEATURES_GUIDE.md#neural-reranking-configuration)
 - **SSCG Integration**: Structural-Semantic Code Graph — on the [SSCG benchmark](#benchmark-results) (2026-04-10, 13 queries, k=10; cutoffs @5/@10): **13/13 Hit@5 across all three modes (hybrid, BM25, semantic); BM25 MRR=0.846 (best overall)**
 - **63% Token Reduction**: Real-world benchmarked mixed approach - [benchmarks](docs/BENCHMARKS.md)
 - **Multi-Model Routing**: Intelligent query routing (Qwen3, BGE-M3, CodeRankEmbed) with 100% accuracy - [advanced features](docs/ADVANCED_FEATURES_GUIDE.md)
+- **ONNX Runtime Backend** (opt-in): `performance.use_onnx` loads eligible models via `ORTModelForFeatureExtraction` with `CUDAExecutionProvider` + `gpu_mem_limit` arena cap — prevents WDDM shared-memory spillover on 8 GB laptop GPUs
 - **19 File Extensions**: Python, JS, TS, Go, Rust, C/C++, C#, GLSL with AST/tree-sitter chunking
 - **19 MCP Tools**: Complete Claude Code integration - [tool reference](docs/MCP_TOOLS_REFERENCE.md)
 - **Source-Position Reranking**: Groups results by file, sorted by line number — LLMs read code in logical order (+5.3% accuracy, DOS RAG)
 - **Centrality-Adaptive BM25 Boost**: High-centrality nodes (base classes, utilities) get BM25 score boost — compensates for single-vector ceiling (DeepMind LIMIT, ICLR 2026)
 - **File-Role Tagging**: Chunks tagged `role:src/test/doc/config` at index time — enables role-aware ranking and precision boosts
 
-**Status**: ✅ Production-ready | 1,682+ passing tests | All 19 MCP tools operational | Windows 10/11
+**Status**: ✅ Production-ready | 1,985+ passing tests | All 19 MCP tools operational | Windows 10/11
 
 ## Quick Start
 

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -34,6 +34,34 @@ This file maintains session memory and context for the Claude-context-MCP semant
 
 ## Session History
 
+### 2026-04-16: CI Review Fixes Applied to Development
+
+**Primary Achievement**: Verified CI review agent findings against code and applied all valid fixes in 3 logical commits (ONNX correctness, VRAM/OOM robustness, cosmetics).
+
+#### Key Fixes
+
+- **A: ONNX correctness** — deleted duplicated ORT provider-options block (L304-357 of `onnx_loader.py`; the second copy was the one wired to `from_pretrained`); fixed `_measure_activation_per_item` to accept `cuda:N` device strings (was `!= "cuda"`, now `startswith`); ONNX path no longer requires torch for NVML-based measurement; updated `validate()` docstring to say "max abs diff" not "cosine diff".
+- **B: VRAM/OOM robustness** — OOM detection now prefers `isinstance(e, torch.cuda.OutOfMemoryError)` with string-match fallback; `estimate_activation_gb_from_config` is now dtype-aware (fp32 → 4 bytes, fp16/bf16 → 2 bytes, unknown → 2); `ort_untracked_gb` key in status handler renamed to `non_torch_gb` (was mathematically wrong: subtracted per-process from device-wide NVML); added missing test for non-OOM RuntimeError propagation.
+- **C: Cosmetics** — added `onnx_pooling: "mean"` to `BAAI/bge-code-v1` and `nomic-ai/CodeRankEmbed` in `MODEL_REGISTRY`; narrowed `TypeError` from except tuples in `compute_effective_vram_cap`/`set_vram_limit`; DEBUG-logged previously silent excepts; fixed `onnx_gpu_mem_limit` field style; added `mem_get_info(0)` explicit index for consistency; added comment explaining ORT cap computed once before batch loop.
+
+#### Config Default Switch (intentional)
+
+`search_config.json` defaults were updated when the multi-model pool was switched to `lightweight-speed` for this laptop target:
+- `model_name`: Qwen3-Embedding-0.6B → `BAAI/bge-m3`
+- `default_model`: `qwen3` → `bge_m3`
+- `reranker`: `jinaai/jina-reranker-v3` → `Alibaba-NLP/gte-reranker-modernbert-base`
+- `multi_model_pool`: `full` → `lightweight-speed`
+
+**Existing users must re-index** if upgrading from a Qwen3-based index (dimension unchanged at 1024, but model weights differ).
+
+#### CI False Positives (not fixed — already correct)
+
+- `_resolve_provider` already uses `device.startswith("cuda")` (CI claimed literal match).
+- ONNX fast-path fallback already catches both `ImportError` and `RuntimeError` (CI said only `ImportError`).
+- `allow_ram_fallback` in `search_config.json` is `true` (CI claimed `false`).
+
+---
+
 ### 2026-04-16: ONNX Stack Merged Into Development
 
 **Primary Achievement**: Finalized the 4-PR ONNX Runtime stack by resolving merge conflicts, committing the merge into `development`, pushing to origin, and closing all 4 stacked PRs with a reference to the merge commit.

--- a/docs/ADVANCED_FEATURES_GUIDE.md
+++ b/docs/ADVANCED_FEATURES_GUIDE.md
@@ -295,7 +295,7 @@ set CLAUDE_MULTI_MODEL_ENABLED=false
 /configure_query_routing
 {
   "multi_model_enabled": true,
-  "default_model": "qwen3",
+  "default_model": "bge_m3",
   "confidence_threshold": 0.35
 }
 ```
@@ -303,7 +303,7 @@ set CLAUDE_MULTI_MODEL_ENABLED=false
 **Routing Parameters**:
 
 - `multi_model_enabled`: Toggle multi-model routing (default: true)
-- `default_model`: Fallback model for low-confidence queries (default: "qwen3")
+- `default_model`: Fallback model for low-confidence queries (default: `"bge_m3"` for the `lightweight-speed` pool, `"qwen3"` for the full pool)
 - `confidence_threshold`: Minimum confidence to use non-default model (default: 0.35, benchmark-verified)
 
 ### Usage Examples
@@ -353,16 +353,16 @@ set CLAUDE_MULTI_MODEL_ENABLED=false
 **Model Pool Configuration**:
 
 ```python
-# Full pool (10GB+ VRAM) - Default for desktop/workstation
-MODEL_POOL_CONFIG = {
-    "qwen3": "Qwen/Qwen3-Embedding-0.6B",  # Logic & implementation specialist
-    "bge_code": "BAAI/bge-code-v1",         # Workflow & code structure specialist
-}
-
-# Lightweight pool (6-10GB VRAM) - Laptop tier
+# Lightweight pool (6-10GB VRAM) - Default (8 GB laptop tier, ships in search_config.json)
 MODEL_POOL_CONFIG_LIGHTWEIGHT_SPEED = {
     "gte_modernbert": "Alibaba-NLP/gte-modernbert-base",  # Code-specific queries
-    "bge_m3": "BAAI/bge-m3",                             # General queries
+    "bge_m3": "BAAI/bge-m3",                              # General queries
+}
+
+# Full pool (10GB+ VRAM) - Opt-in for desktop/workstation (set routing.multi_model_pool: "full")
+MODEL_POOL_CONFIG = {
+    "qwen3": "Qwen/Qwen3-Embedding-0.6B",  # Logic & implementation specialist
+    "bge_code": "BAAI/bge-code-v1",        # Workflow & code structure specialist
 }
 ```
 

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -6,8 +6,8 @@ Complete version history and feature timeline for claude-context-local MCP serve
 
 - **Version**: 0.11.0
 - **Status**: Production-ready
-- **Test Coverage**: 1,985 unit tests + 8 integration tests (100% pass rate)
-- **Dependencies**: 125 packages (38% reduction from 201) + optional `onnxruntime-gpu` for ONNX backend
+- **Test Coverage**: 1,987 unit tests + 8 integration tests (100% pass rate)
+- **Dependencies**: 124 packages (38% reduction from 201) + optional `onnxruntime-gpu` for ONNX backend
 - **SSCG Benchmark**: MRR=0.94, Recall@4=0.89 (12/13 queries)
 - **Token Reduction**: 63% (validated benchmark, Mixed approach vs traditional)
 - **Recent Features**: ONNX Runtime backend (opt-in), ORT CUDA arena cap, BFCArena OOM recovery, dtype-aware activation estimate, `onnx_supported` registry flag, lightweight-speed default pool (BGE-M3 + gte-reranker-modernbert-base)
@@ -43,7 +43,7 @@ Production-grade ONNX Runtime backend with Windows-WDDM-safe VRAM caps, BFCArena
 
 ### ✅ Verification
 
-- 1,985 unit tests pass (including new `test_handle_get_memory_status_gpu_key_rename`, `TestEstimateActivationDtypeAwareness`, `TestMeasureActivationPerItem`)
+- 1,987 unit tests pass (including new `test_handle_get_memory_status_gpu_key_rename`, `TestEstimateActivationDtypeAwareness`, `TestMeasureActivationPerItem`)
 - Charlie CI re-reviewed PR #24: all blocking items resolved, verdict "Ready to merge"
 - Smoke-tested on 8 GB RTX laptop: BGE-M3 via ONNX produces zero shared-memory spillover under the ORT cap
 

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -2,15 +2,50 @@
 
 Complete version history and feature timeline for claude-context-local MCP server.
 
-## Current Status: All Features Operational (2026-04-09)
+## Current Status: All Features Operational (2026-04-16)
 
-- **Version**: 0.10.0
+- **Version**: 0.11.0
 - **Status**: Production-ready
-- **Test Coverage**: 1,682 unit tests + 8 integration tests (100% pass rate)
-- **Dependencies**: 125 packages (38% reduction from 201)
+- **Test Coverage**: 1,985 unit tests + 8 integration tests (100% pass rate)
+- **Dependencies**: 125 packages (38% reduction from 201) + optional `onnxruntime-gpu` for ONNX backend
 - **SSCG Benchmark**: MRR=0.94, Recall@4=0.89 (12/13 queries)
 - **Token Reduction**: 63% (validated benchmark, Mixed approach vs traditional)
-- **Recent Features**: Source-position reranking (DOS RAG), centrality-adaptive BM25 boost, file-role tagging, lower chunk split/merge thresholds (1600 chars / 400 tokens)
+- **Recent Features**: ONNX Runtime backend (opt-in), ORT CUDA arena cap, BFCArena OOM recovery, dtype-aware activation estimate, `onnx_supported` registry flag, lightweight-speed default pool (BGE-M3 + gte-reranker-modernbert-base)
+
+---
+
+## v0.11.0 - ONNX Runtime Backend + VRAM Robustness (2026-04-16)
+
+### Status: FEATURE RELEASE ✅
+
+Production-grade ONNX Runtime backend with Windows-WDDM-safe VRAM caps, BFCArena OOM recovery, and per-model activation measurement. Verified against Charlie CI review on PR #24.
+
+### Highlights
+
+- **ONNX Runtime backend** (opt-in via `performance.use_onnx`): loads eligible models via `ORTModelForFeatureExtraction` with `CUDAExecutionProvider`. Auto-converts HuggingFace → ONNX on first use. Supported pooling: `cls`, `mean`. Models can opt out via `onnx_supported: False` (used for BGE-code-v1, whose upstream `lasttoken` pooling is not yet wrappable).
+- **ORT CUDA arena cap** (`performance.onnx_gpu_mem_limit`, default `true`): passes the same effective VRAM cap to ORT's `gpu_mem_limit` provider option that the PyTorch path applies via `set_per_process_memory_fraction()`. Prevents WDDM shared-memory spillover on Windows when external processes hold VRAM. Check `[ONNX_VRAM]` log lines.
+- **BFCArena OOM recovery**: `CodeEmbedder.embed_chunks` detects ORT OOM (`BFCArena`, `"available memory" + "smaller than requested"`) and halves the dynamic batch size the same way PyTorch `OutOfMemoryError` recovery already did.
+- **Per-model activation measurement** (`ModelLoader._measure_activation_per_item`): Tier-1 runtime measurement via PyTorch memory stats (torch path) or NVML snapshots (ONNX path). Replaces hardcoded per-model activation constants for models without explicit floors.
+- **Default pool → lightweight-speed**: `search_config.json` ships with `BAAI/bge-m3` (embeddings) + `Alibaba-NLP/gte-reranker-modernbert-base` (reranker). Targeted at 8 GB laptop GPUs with zero shared-memory spillover under the ORT cap.
+
+### 🔧 Changes
+
+- `search_config.json` — default `embedding.model_name: "BAAI/bge-m3"`, `reranker.model_name: "Alibaba-NLP/gte-reranker-modernbert-base"`, `routing.multi_model_pool: "lightweight-speed"`, `routing.default_model: "bge_m3"`, `performance.use_onnx: true`, `performance.onnx_gpu_mem_limit: true`
+- `embeddings/onnx_loader.py` + `embeddings/onnx_wrapper.py` — new modules; `ONNXEmbeddingModel` wrapper exposes SentenceTransformer-compatible `.encode()` with `cls`/`mean` pooling
+- `embeddings/model_loader.py` — `_should_use_onnx()` gate (checks `use_onnx` + `trust_remote_code` + `onnx_supported`); `_measure_activation_per_item()` accepts `cuda:N`
+- `embeddings/embedder.py` — `isinstance(torch.cuda.OutOfMemoryError)` OOM detection + ORT string fallback; dtype-aware `estimate_activation_gb_from_config()`
+- `search/config.py` — `MODEL_REGISTRY` + `MODEL_POOL_CONFIG_LIGHTWEIGHT_SPEED`; `onnx_pooling` declared per model; `onnx_supported: False` added to BGE-code-v1
+- `mcp_server/tools/status_handlers.py` — **breaking**: GPU entries now expose `non_torch_gb` (was `ort_untracked_gb`); old name was misleading since the computed value conflates other processes + drivers + ORT
+
+### 🚨 Breaking Changes
+
+- `handle_get_memory_status()` GPU entries: `ort_untracked_gb` → `non_torch_gb`. External dashboards or monitors reading the old key receive `None`.
+
+### ✅ Verification
+
+- 1,985 unit tests pass (including new `test_handle_get_memory_status_gpu_key_rename`, `TestEstimateActivationDtypeAwareness`, `TestMeasureActivationPerItem`)
+- Charlie CI re-reviewed PR #24: all blocking items resolved, verdict "Ready to merge"
+- Smoke-tested on 8 GB RTX laptop: BGE-M3 via ONNX produces zero shared-memory spillover under the ORT cap
 
 ---
 

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -3,6 +3,8 @@
 Supports multiple embedding models including:
 - EmbeddingGemma (google/embeddinggemma-300m)
 - BGE-M3 (BAAI/bge-m3)
+
+Single-GPU assumption: all torch.cuda.* calls target device index 0.
 """
 
 import contextlib
@@ -273,7 +275,7 @@ def compute_effective_vram_cap(
             other_b / 1024**3,
             headroom_b / 1024**3,
         )
-    except (RuntimeError, ValueError, AssertionError, TypeError):
+    except (RuntimeError, ValueError, AssertionError):
         return None
 
 
@@ -399,7 +401,7 @@ def calculate_optimal_batch_size(
 
     try:
         # Get system-wide free/total GPU memory (accounts for ALL processes)
-        free_memory, total_memory = torch.cuda.mem_get_info()
+        free_memory, total_memory = torch.cuda.mem_get_info(0)
         total_gb = total_memory / (1024**3)
         free_gb = free_memory / (1024**3)
 
@@ -1053,8 +1055,10 @@ class CodeEmbedder:
             _embed_cfg = _get_config_via_service_locator()
             if _embed_cfg and _embed_cfg.performance:
                 set_vram_limit(_embed_cfg.performance.vram_limit_fraction)
-        except (RuntimeError, AttributeError):
-            pass  # keep the __init__-time cap on failure
+        except (RuntimeError, AttributeError) as _cap_err:
+            self._logger.debug(
+                "Ignoring %s re-applying VRAM cap", type(_cap_err).__name__
+            )
 
         # Load batch size from config if not explicitly provided
         if batch_size is None:
@@ -1121,9 +1125,8 @@ class CodeEmbedder:
                     0.05, min(memory_fraction, 0.95)
                 )  # Clamp to safe range
 
-                # For ONNX backend: tell the batch sizer about the ORT arena cap so
-                # it uses ORT-remaining budget (cap − model_weights) as available_gb
-                # instead of system-wide free memory (which ORT cannot fully use).
+                # ORT cap: gpu_mem_limit is static (set at from_pretrained time), so
+                # computing it once here (not per-batch) is correct and sufficient.
                 ort_cap_gb = 0.0
                 if hasattr(self._model, "ort_model"):
                     try:
@@ -1132,8 +1135,10 @@ class CodeEmbedder:
                         )
                         if _cap_result is not None:
                             ort_cap_gb = _cap_result[1] / 1024**3  # bytes → GB
-                    except Exception:
-                        pass
+                    except Exception as _ort_err:
+                        self._logger.debug(
+                            "Ignoring %s computing ORT cap", type(_ort_err).__name__
+                        )
 
                 batch_size = calculate_optimal_batch_size(
                     embedding_dim=config.embedding.dimension,

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -96,6 +96,10 @@ _GATED_MLP_MODEL_TYPES = frozenset(
     }
 )
 
+# Known PyTorch CUDA OOM message shapes — compat fallback for torch builds
+# where torch.cuda.OutOfMemoryError is not a distinct exception class.
+_PYTORCH_OOM_STRINGS = ("cuda out of memory", "torch.cuda.outofmemoryerror")
+
 
 def estimate_activation_gb_from_config(
     config: Any,
@@ -1247,7 +1251,10 @@ class CodeEmbedder:
                         "available memory" in err_str
                         and "smaller than requested" in err_str
                     )
-                    is_oom = is_torch_oom or is_ort_oom or "out of memory" in err_str
+                    is_legacy_torch_oom = any(
+                        s in err_str for s in _PYTORCH_OOM_STRINGS
+                    )
+                    is_oom = is_torch_oom or is_ort_oom or is_legacy_torch_oom
                     if is_oom and current_batch_size > 1:
                         new_size = max(1, current_batch_size // 2)
                         self._logger.warning(

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -141,7 +141,11 @@ def estimate_activation_gb_from_config(
         or 4 * hidden
     )
     model_type: str = getattr(config, "model_type", "").lower()
-    dtype_bytes: int = 2  # bf16 / fp16 (both 2 bytes)
+    _dtype = getattr(config, "torch_dtype", None)
+    _fp32 = getattr(torch, "float32", None) if torch is not None else None
+    dtype_bytes: int = (
+        4 if (_dtype is not None and _dtype == _fp32 or _dtype == "float32") else 2
+    )
 
     has_gated_mlp = model_type in _GATED_MLP_MODEL_TYPES
 
@@ -1225,15 +1229,20 @@ class CodeEmbedder:
                     # position with a smaller batch.  Applies to both PyTorch CUDA OOM
                     # (torch.cuda.OutOfMemoryError subclasses RuntimeError) and ORT BFCArena OOM
                     # ("BFCArena::AllocateRawInternal Available memory … smaller than requested").
-                    err_str = str(e).lower()
-                    is_oom = (
-                        "out of memory" in err_str
-                        or "bfcarena" in err_str
-                        or (
-                            "available memory" in err_str
-                            and "smaller than requested" in err_str
-                        )
+                    _oom_type = (
+                        getattr(torch.cuda, "OutOfMemoryError", None)
+                        if torch is not None
+                        else None
                     )
+                    is_torch_oom = isinstance(_oom_type, type) and isinstance(
+                        e, _oom_type
+                    )
+                    err_str = str(e).lower()
+                    is_ort_oom = "bfcarena" in err_str or (
+                        "available memory" in err_str
+                        and "smaller than requested" in err_str
+                    )
+                    is_oom = is_torch_oom or is_ort_oom or "out of memory" in err_str
                     if is_oom and current_batch_size > 1:
                         new_size = max(1, current_batch_size // 2)
                         self._logger.warning(

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -96,9 +96,11 @@ _GATED_MLP_MODEL_TYPES = frozenset(
     }
 )
 
-# Known PyTorch CUDA OOM message shapes — compat fallback for torch builds
-# where torch.cuda.OutOfMemoryError is not a distinct exception class.
-_PYTORCH_OOM_STRINGS = ("cuda out of memory", "torch.cuda.outofmemoryerror")
+# Known PyTorch CUDA OOM message text — compat fallback for legacy torch
+# builds where torch.cuda.OutOfMemoryError is not a distinct exception class.
+# str(exception).lower() yields the message text (not the class name), so only
+# message-shape strings belong here. Kept as a tuple for future extensibility.
+_PYTORCH_OOM_STRINGS = ("cuda out of memory",)
 
 
 def estimate_activation_gb_from_config(
@@ -149,6 +151,8 @@ def estimate_activation_gb_from_config(
     model_type: str = getattr(config, "model_type", "").lower()
     _dtype = getattr(config, "torch_dtype", None)
     _fp32 = getattr(torch, "float32", None) if torch is not None else None
+    # fp32 doubles activation memory vs fp16/bf16. float64 is not used by
+    # embedding models in practice and is treated as fp16 here (2 bytes).
     dtype_bytes: int = (
         4 if ((_dtype is not None and _dtype == _fp32) or _dtype == "float32") else 2
     )

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -146,7 +146,7 @@ def estimate_activation_gb_from_config(
     _dtype = getattr(config, "torch_dtype", None)
     _fp32 = getattr(torch, "float32", None) if torch is not None else None
     dtype_bytes: int = (
-        4 if (_dtype is not None and _dtype == _fp32 or _dtype == "float32") else 2
+        4 if ((_dtype is not None and _dtype == _fp32) or _dtype == "float32") else 2
     )
 
     has_gated_mlp = model_type in _GATED_MLP_MODEL_TYPES

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -337,6 +337,8 @@ class ModelLoader:
         Eligibility requires:
         - use_onnx=True in performance config
         - Model does NOT require trust_remote_code (custom architectures unsupported)
+        - Model does NOT set onnx_supported=False (opt-out for models whose upstream
+          pooling is not yet implemented in onnx_wrapper.py, e.g. lasttoken)
         """
         try:
             from mcp_server.utils.config_helpers import (
@@ -353,6 +355,12 @@ class ModelLoader:
         if model_config.get("trust_remote_code", False):
             self._logger.debug(
                 f"[ONNX] Skipping {self.model_name!r}: trust_remote_code=True"
+            )
+            return False
+        if not model_config.get("onnx_supported", True):
+            self._logger.debug(
+                f"[ONNX] Skipping {self.model_name!r}: onnx_supported=False "
+                "(upstream pooling not supported by wrapper)"
             )
             return False
         return True

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -360,7 +360,7 @@ class ModelLoader:
         if not model_config.get("onnx_supported", True):
             self._logger.debug(
                 f"[ONNX] Skipping {self.model_name!r}: onnx_supported=False "
-                "(upstream pooling not supported by wrapper)"
+                f"(upstream pooling not supported by wrapper)"
             )
             return False
         return True

--- a/embeddings/model_loader.py
+++ b/embeddings/model_loader.py
@@ -167,7 +167,9 @@ class ModelLoader:
         Returns:
             Measured activation memory per item in GB, or 0.0 on failure.
         """
-        if device != "cuda" or (torch is None or not torch.cuda.is_available()):
+        if not str(device).startswith("cuda"):
+            return 0.0
+        if not is_onnx and (torch is None or not torch.cuda.is_available()):
             return 0.0
 
         dummy_batch = [_WARMUP_TEXT] * batch_size

--- a/embeddings/onnx_loader.py
+++ b/embeddings/onnx_loader.py
@@ -356,61 +356,6 @@ class ONNXModelLoader:
                 except Exception as _e:
                     _log.debug(f"[ONNX_VRAM] Could not compute cap (non-fatal): {_e}")
 
-            # Constrain ORT's own CUDA arena allocator so it cannot push the GPU
-            # into WDDM shared-memory spillover on Windows.
-            # Unlike PyTorch's set_per_process_memory_fraction (which ORT ignores),
-            # gpu_mem_limit is respected by the CUDAExecutionProvider arena.
-            # Uses the same effective-cap formula as set_vram_limit() so both
-            # backends share the same budget.  Not applied for CPUExecutionProvider.
-            provider_options = None
-            if provider == "CUDAExecutionProvider":
-                try:
-                    from embeddings.embedder import compute_effective_vram_cap
-                    from mcp_server.utils.config_helpers import (
-                        get_config_via_service_locator as _get_cfg,
-                    )
-
-                    _cfg = _get_cfg()
-                    _fraction = (
-                        _cfg.performance.vram_limit_fraction
-                        if _cfg and _cfg.performance
-                        else 0.80
-                    )
-                    _onnx_cap_enabled = (
-                        _cfg.performance.onnx_gpu_mem_limit
-                        if _cfg and _cfg.performance
-                        else True
-                    )
-                    if _onnx_cap_enabled:
-                        _cap_result = compute_effective_vram_cap(_fraction)
-                        if _cap_result is not None:
-                            (
-                                _,
-                                _cap_bytes,
-                                _free_gb,
-                                _us_gb,
-                                _other_gb,
-                                _headroom_gb,
-                            ) = _cap_result
-                            provider_options = [
-                                {
-                                    "gpu_mem_limit": int(_cap_bytes),
-                                    "arena_extend_strategy": "kSameAsRequested",
-                                }
-                            ]
-                            _log.info(
-                                f"[ONNX_VRAM] gpu_mem_limit={_cap_bytes / 1024**3:.2f}GB, "
-                                f"arena=kSameAsRequested "
-                                f"(free={_free_gb:.1f}GB, us={_us_gb:.1f}GB, "
-                                f"other={_other_gb:.1f}GB, headroom={_headroom_gb:.1f}GB)"
-                            )
-                        else:
-                            _log.debug(
-                                "[ONNX_VRAM] CUDA not available — gpu_mem_limit not set"
-                            )
-                except Exception as _e:
-                    _log.debug(f"[ONNX_VRAM] Could not compute cap (non-fatal): {_e}")
-
             # Suppress benign "incorrect regex pattern" warning from transformers.
             # BGE-M3 uses a Mistral-derived tokenizer that triggers this via logger.warning()
             # (not warnings.warn), so we must temporarily raise the transformers log level.

--- a/mcp_server/tools/status_handlers.py
+++ b/mcp_server/tools/status_handlers.py
@@ -202,9 +202,8 @@ async def handle_get_memory_status(arguments: dict[str, Any]) -> dict:
     gpu_memory = {}
     if torch.cuda.is_available():
         # Try pynvml for device-wide VRAM (sum of all processes + drivers + ORT).
-        # NOTE: nvmlDeviceGetMemoryInfo().used is NOT per-process; it reflects total
-        # allocations on the GPU. A proper per-process reading would require
-        # nvmlDeviceGetComputeRunningProcesses() filtered by os.getpid().
+        # NOTE: nvmlDeviceGetMemoryInfo().used is device-wide, NOT per-process.
+        # non_torch_gb approximates non-PyTorch usage but includes other processes.
         nvml_available = False
         try:
             import pynvml
@@ -249,7 +248,7 @@ async def handle_get_memory_status(arguments: dict[str, Any]) -> dict:
                 entry["utilization_percent"] = (
                     round((real_used_gb / total_vram * 100), 1) if total_vram > 0 else 0
                 )
-                entry["ort_untracked_gb"] = round(
+                entry["non_torch_gb"] = round(
                     max(0.0, real_used_gb - torch_allocated), 2
                 )
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,34 +107,34 @@ include = ["chunking*", "embeddings*", "mcp_server*", "search*", "merkle*"]
 # Security: Minimum versions for CVE fixes
 # Direct dependencies: Updated in dependencies list above
 # Transitive dependencies: Installed automatically, documented here for tracking
-# Last audit: 2026-04-09 (pip-audit - 1 advisory: sqlitedict CVE-2024-35515, mitigated)
+# Last audit: 2026-04-16 (pip-audit - 2 advisories: sqlitedict CVE-2024-35515 mitigated,
+#             transformers CVE-2026-1839 blocked by optimum-onnx <4.58.0 pin)
 #
 # Direct dependency security updates:
 # mcp>=1.27.0        # Fixes CVE-2025-66416 (DNS rebinding vulnerability)
 # nltk>=3.9.4        # Fixes CVE-2025-14009 (path traversal in zipfile.extractall)
 # aiohttp>=3.13.5    # Fixes CVE-2025-69223 through CVE-2025-69230
-# cryptography>=46.0.7  # Fixes CVE-2026-26007, CVE-2026-39892 (buffer overflow)
 #
 # Transitive dependency security updates:
-# authlib>=1.6.5     # Fixes CVE-2025-59420, CVE-2025-61920, CVE-2025-62706
-# pip>=26.0.1        # Fixes CVE-2025-8869 (tarfile path traversal), CVE-2026-1703
-# python-multipart>=0.0.24  # Fixes CVE-2026-24486 (path traversal in file uploads)
-# starlette>=0.51.0  # Fixes CVE (version: 0.47.3 → 0.51.0)
-# uv>=0.11.6         # Fixes 2 CVEs (version: 0.8.21 → 0.9.6)
-# werkzeug>=3.1.4    # Fixes CVE-2025-66221 (Windows device name handling)
-# wheel>=0.46.3      # Fixes CVE-2026-24049 (path traversal in unpack)
+# pip>=26.0.1              # Fixes CVE-2025-8869 (tarfile path traversal), CVE-2026-1703
+# python-multipart>=0.0.26 # Fixes CVE-2026-24486 (path traversal), CVE-2026-40347 (DoS in multipart parser)
+# pygments>=2.20.0         # Fixes CVE-2026-4539 (ReDoS in AdlLexer)
+# pyjwt>=2.12.0            # Fixes CVE-2026-32597 (JWS crit header not validated)
+# requests>=2.33.0         # Fixes CVE-2026-25645 (predictable tempfile name)
+# starlette>=0.51.0        # Fixes CVE (version: 0.47.3 → 0.51.0)
+# uv>=0.11.6               # Fixes 2 CVEs (version: 0.8.21 → 0.9.6)
+# werkzeug>=3.1.4          # Fixes CVE-2025-66221 (Windows device name handling)
+# wheel>=0.46.3            # Fixes CVE-2026-24049 (path traversal in unpack)
 #
 # Verification: .venv/Scripts/pip-audit --format json | .venv/Scripts/python.exe tools/summarize_audit.py
 #
-# Safe patch updates (tested 2026-04-09):
-# * cryptography (46.0.6 -> 46.0.7), pytest (9.0.2 -> 9.0.3), mcp (1.26.0 -> 1.27.0).
-# * python-dotenv (1.2.1 -> 1.2.2), python-multipart (0.0.22 -> 0.0.24).
-# * pip-licenses (5.5.1 -> 5.5.5), pipdeptree (2.30.0 -> 2.34.0), pydantic-settings (2.12.0 -> 2.13.1).
-# * sse-starlette (3.2.0 -> 3.3.4), tree-sitter-rust (0.24.0 -> 0.24.2), uv (0.11.3 -> 0.11.6), ruff (0.15.9 -> 0.15.10).
-# * pyjwt (2.10.1 -> 2.12.1), pygments (2.19.2 -> 2.20.0), requests (2.32.5 -> 2.33.1).
-# * pytest-cov (6.2.1 -> 7.1.0), uvicorn (0.40.0 -> 0.44.0).
-# Tested: 1719 unit tests pass, pip check passed.
-# Remaining CVEs: 1 (sqlitedict CVE-2024-35515 - no upstream fix; mitigated via JSON serialization in metadata.py).
+# Safe patch updates (tested 2026-04-16):
+# * pygments (2.19.2 -> 2.20.0), pyjwt (2.10.1 -> 2.12.0), requests (2.32.5 -> 2.33.0).
+# * python-multipart (0.0.22 -> 0.0.26).
+# * Orphans removed: cryptography, typer-slim, shellingham (no dependents; eliminated 2 CVEs).
+# Tested: 1987 unit tests pass, pip check passed.
+# Remaining CVEs: 2 (sqlitedict CVE-2024-35515 - no upstream fix, mitigated via JSON serialization in metadata.py;
+#                    transformers CVE-2026-1839 - fix requires 5.0.0rc3, blocked by optimum-onnx <4.58.0 pin).
 
 [tool.uv]
 index-url = "https://pypi.org/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-context-local"
-version = "0.10.1"
+version = "0.11.0"
 description = "Local semantic code search for Claude Code (MCP) using multi-model routing (Qwen3, BGE-M3, CodeRankEmbed), FAISS, and AST/tree-sitter chunking. 100% local embeddings and indexing."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/search/config.py
+++ b/search/config.py
@@ -26,6 +26,14 @@ MODEL_POOL_CONFIG_LIGHTWEIGHT_SPEED = {
     "bge_m3": "BAAI/bge-m3",
 }
 
+# MODEL_REGISTRY convention for ONNX support:
+# - "onnx_supported": False  -> ONNX path is skipped in _should_use_onnx().
+#   Use this when the upstream pooling mode is not handled by
+#   embeddings/onnx_wrapper.py (which supports only "cls" and "mean").
+# - Key absent (or True)     -> ONNX path allowed, subject to other gates
+#   (trust_remote_code, performance.use_onnx, etc.).
+# New models with non-cls/mean pooling (lasttoken, weightedmean, etc.) MUST
+# set onnx_supported: False explicitly until onnx_wrapper.py gains support.
 MODEL_REGISTRY = {
     "google/embeddinggemma-300m": {
         "dimension": 768,

--- a/search/config.py
+++ b/search/config.py
@@ -51,7 +51,9 @@ MODEL_REGISTRY = {
         "vram_gb": "4GB",  # ~4GB in FP16
         "fallback_batch_size": 32,  # Conservative batch size for 2B model
         "trust_remote_code": False,
-        "onnx_pooling": "mean",
+        # Upstream uses lasttoken pooling, which the ONNX wrapper does not yet support.
+        # Gate ONNX off for this model until lasttoken support lands in onnx_wrapper.py.
+        "onnx_supported": False,
     },
     "Qwen/Qwen3-Embedding-0.6B": {
         "dimension": 1024,
@@ -79,7 +81,8 @@ MODEL_REGISTRY = {
         "model_type": "code-specific",
         "task_instruction": "Represent this query for searching relevant code",  # Required query prefix
         "trust_remote_code": True,
-        "onnx_pooling": "mean",
+        # Upstream pooling is CLS; `.get("onnx_pooling", "cls")` in model_loader
+        # defaults correctly. ONNX is blocked anyway via trust_remote_code=True.
     },
     "Alibaba-NLP/gte-modernbert-base": {
         "dimension": 768,

--- a/search/config.py
+++ b/search/config.py
@@ -51,6 +51,7 @@ MODEL_REGISTRY = {
         "vram_gb": "4GB",  # ~4GB in FP16
         "fallback_batch_size": 32,  # Conservative batch size for 2B model
         "trust_remote_code": False,
+        "onnx_pooling": "mean",
     },
     "Qwen/Qwen3-Embedding-0.6B": {
         "dimension": 1024,
@@ -78,6 +79,7 @@ MODEL_REGISTRY = {
         "model_type": "code-specific",
         "task_instruction": "Represent this query for searching relevant code",  # Required query prefix
         "trust_remote_code": True,
+        "onnx_pooling": "mean",
     },
     "Alibaba-NLP/gte-modernbert-base": {
         "dimension": 768,
@@ -234,12 +236,9 @@ class PerformanceConfig:
     use_onnx: bool = (
         False  # When True, loads eligible models via ORTModelForFeatureExtraction
     )
-    onnx_gpu_mem_limit: bool = (
-        True  # Constrain ORT CUDAExecutionProvider arena via gpu_mem_limit.
-        # Uses the same effective-cap formula as set_vram_limit() so the ONNX
-        # session cannot push the GPU into WDDM shared-memory spillover.
-        # Disable only for debugging (raises OOM instead of spilling if too tight).
-    )
+    # Constrain ORT CUDAExecutionProvider arena (same formula as set_vram_limit()).
+    # Disable only for debugging — prevents WDDM spillover for ONNX sessions.
+    onnx_gpu_mem_limit: bool = True
 
     # Auto-reindexing
     enable_auto_reindex: bool = True

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -1691,3 +1691,98 @@ class TestOomRecoveryBackoff:
         # First call fails with batch=4, then all subsequent calls use batch=2
         assert batch_sizes_seen[0] == 4  # the failing attempt
         assert all(s == 2 for s in batch_sizes_seen[1:])  # all retries use 2
+
+    @patch("embeddings.embedder.torch")
+    @patch("embeddings.embedder._get_config_via_service_locator")
+    def test_non_oom_runtime_error_propagates(self, mock_get_cfg, mock_torch):
+        """A RuntimeError whose message is not OOM-related must propagate, not trigger halving."""
+        from embeddings.embedder import CodeEmbedder
+
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.is_tensor = MagicMock(return_value=False)
+        # Ensure isinstance(e, torch.cuda.OutOfMemoryError) is False
+        mock_torch.cuda.OutOfMemoryError = type("OutOfMemoryError", (RuntimeError,), {})
+
+        cfg = MagicMock()
+        cfg.performance.enable_dynamic_batch_size = False
+        cfg.performance.allow_ram_fallback = True
+        cfg.embedding.batch_size = 4
+        cfg.embedding.dimension = 768
+        mock_get_cfg.return_value = cfg
+
+        embedder = CodeEmbedder.__new__(CodeEmbedder)
+        embedder._logger = MagicMock()
+        embedder.model_name = "test/model"
+        embedder.device = "cpu"
+        embedder._query_cache = MagicMock()
+        embedder._model_vram_usage = {}
+        embedder._model_warmed_up = True
+        embedder._check_vram_status = MagicMock(return_value=(0.5, False, False))
+        embedder._log_vram_usage = MagicMock()
+        embedder._is_gpu_device = MagicMock(return_value=False)
+        embedder._get_model_config = MagicMock(return_value={"passage_prefix": ""})
+
+        initial_batch_size = 4
+        embedder._current_batch_size = initial_batch_size
+
+        fake_model = MagicMock()
+        fake_model.encode.side_effect = RuntimeError("invalid device function")
+        embedder._model = fake_model
+        embedder.create_embedding_content = MagicMock(side_effect=lambda c: c.content)
+
+        with pytest.raises(RuntimeError, match="invalid device function"):
+            embedder.embed_chunks(self._make_chunks(4))
+
+        assert embedder._current_batch_size == initial_batch_size
+
+
+# ---------------------------------------------------------------------------
+# estimate_activation_gb_from_config — dtype-awareness
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateActivationDtypeAwareness:
+    """Verify estimate_activation_gb_from_config uses correct byte-width per dtype."""
+
+    def _make_config(self, torch_dtype=None, hidden_size=768, num_attention_heads=12):
+        cfg = MagicMock()
+        cfg.hidden_size = hidden_size
+        cfg.num_attention_heads = num_attention_heads
+        cfg.num_key_value_heads = num_attention_heads
+        cfg.head_dim = None
+        cfg.intermediate_size = 3072
+        cfg.model_type = "bert"
+        cfg.torch_dtype = torch_dtype
+        return cfg
+
+    def test_fp32_dtype_doubles_estimate(self):
+        from embeddings.embedder import estimate_activation_gb_from_config
+
+        cfg_fp16 = self._make_config(torch_dtype="float16")
+        cfg_fp32 = self._make_config(torch_dtype="float32")
+
+        est_fp16 = estimate_activation_gb_from_config(cfg_fp16, is_onnx=False)
+        est_fp32 = estimate_activation_gb_from_config(cfg_fp32, is_onnx=False)
+
+        assert est_fp32 == pytest.approx(est_fp16 * 2, rel=1e-6)
+
+    def test_unknown_dtype_defaults_to_fp16_bytes(self):
+        from embeddings.embedder import estimate_activation_gb_from_config
+
+        cfg_none = self._make_config(torch_dtype=None)
+        cfg_fp16 = self._make_config(torch_dtype="float16")
+
+        est_none = estimate_activation_gb_from_config(cfg_none, is_onnx=False)
+        est_fp16 = estimate_activation_gb_from_config(cfg_fp16, is_onnx=False)
+
+        assert est_none == pytest.approx(est_fp16, rel=1e-6)
+
+    def test_bfloat16_treated_as_2_bytes(self):
+        from embeddings.embedder import estimate_activation_gb_from_config
+
+        cfg_bf16 = self._make_config(torch_dtype="bfloat16")
+        cfg_fp16 = self._make_config(torch_dtype="float16")
+
+        assert estimate_activation_gb_from_config(cfg_bf16) == pytest.approx(
+            estimate_activation_gb_from_config(cfg_fp16), rel=1e-6
+        )

--- a/tests/unit/embeddings/test_model_loader.py
+++ b/tests/unit/embeddings/test_model_loader.py
@@ -521,7 +521,7 @@ class TestMeasureActivationPerItem:
         assert result > 0.0, f"Expected activation measurement for device={device!r}"
         mock_model.encode.assert_called_once()
 
-    @pytest.mark.parametrize("device", ["cuda", "cuda:0"])
+    @pytest.mark.parametrize("device", ["cuda", "cuda:0", "cuda:1"])
     def test_onnx_path_accepts_cuda_index_without_torch(self, tmp_path, device):
         """ONNX path uses NVML; must not short-circuit when torch is unavailable."""
         loader = self._make_loader(tmp_path)

--- a/tests/unit/embeddings/test_model_loader.py
+++ b/tests/unit/embeddings/test_model_loader.py
@@ -465,3 +465,83 @@ class TestModelLoader:
         """Test model_vram_usage property."""
         model_loader._model_vram_usage["test-model"] = 123.4
         assert model_loader.model_vram_usage == {"test-model": 123.4}
+
+
+# ---------------------------------------------------------------------------
+# _measure_activation_per_item — device-string acceptance
+# ---------------------------------------------------------------------------
+
+
+class TestMeasureActivationPerItem:
+    """Verify _measure_activation_per_item handles cuda:N device strings correctly."""
+
+    def _make_loader(self, tmp_path):
+        cache = ModelCacheManager(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(tmp_path),
+            model_config_getter=lambda: {},
+        )
+        loader = ModelLoader(
+            model_name="BAAI/bge-m3",
+            cache_dir=str(tmp_path),
+            device="auto",
+            cache_manager=cache,
+            model_config_getter=lambda: {},
+        )
+        loader._should_use_onnx = lambda: False
+        return loader
+
+    def test_cpu_device_returns_zero(self, tmp_path):
+        loader = self._make_loader(tmp_path)
+        mock_model = Mock()
+        result = loader._measure_activation_per_item(mock_model, "cpu", batch_size=2)
+        assert result == 0.0
+        mock_model.encode.assert_not_called()
+
+    @pytest.mark.parametrize("device", ["cuda", "cuda:0", "cuda:1"])
+    def test_pytorch_path_accepts_cuda_index(self, tmp_path, device):
+        """cuda, cuda:0, and cuda:1 must all pass the device gate for the PyTorch path."""
+        loader = self._make_loader(tmp_path)
+        mock_model = Mock()
+        mock_model.encode.return_value = None
+
+        with (
+            patch("embeddings.model_loader.torch") as mock_torch,
+        ):
+            mock_torch.cuda.is_available.return_value = True
+            mock_torch.cuda.reset_peak_memory_stats.return_value = None
+            # Simulate 50 MB activation delta
+            mock_torch.cuda.memory_allocated.return_value = 100_000_000
+            mock_torch.cuda.max_memory_allocated.return_value = 150_000_000
+
+            result = loader._measure_activation_per_item(
+                mock_model, device, batch_size=2, is_onnx=False
+            )
+
+        assert result > 0.0, f"Expected activation measurement for device={device!r}"
+        mock_model.encode.assert_called_once()
+
+    @pytest.mark.parametrize("device", ["cuda", "cuda:0"])
+    def test_onnx_path_accepts_cuda_index_without_torch(self, tmp_path, device):
+        """ONNX path uses NVML; must not short-circuit when torch is unavailable."""
+        loader = self._make_loader(tmp_path)
+        mock_model = Mock()
+        mock_model.encode.return_value = None
+
+        nvml_values = iter([100_000_000, 160_000_000])
+
+        with (
+            patch("embeddings.model_loader.torch", None),
+            patch(
+                "embeddings.model_loader._get_nvml_used_bytes",
+                side_effect=lambda d: next(nvml_values),
+            ),
+        ):
+            result = loader._measure_activation_per_item(
+                mock_model, device, batch_size=2, is_onnx=True
+            )
+
+        assert result > 0.0, (
+            f"ONNX activation measurement skipped for device={device!r}"
+        )
+        mock_model.encode.assert_called_once()

--- a/tests/unit/mcp_server/test_tool_handlers.py
+++ b/tests/unit/mcp_server/test_tool_handlers.py
@@ -231,6 +231,53 @@ async def test_handle_get_memory_status():
 
 
 @pytest.mark.asyncio
+async def test_handle_get_memory_status_gpu_key_rename():
+    """Key rename guard: the GPU entry must expose `non_torch_gb`, not the old
+    `ort_untracked_gb`. The old name was misleading — it reflects all non-PyTorch
+    allocations (other processes + drivers + ORT), not just ORT."""
+    import mcp_server.tools.status_handlers as status_handlers
+
+    mock_mem = Mock()
+    mock_mem.total = 16 * 1024**3
+    mock_mem.available = 8 * 1024**3
+    mock_mem.used = 8 * 1024**3
+    mock_mem.percent = 50.0
+
+    mock_pynvml = Mock()
+    mock_pynvml.nvmlInit = Mock()
+    mock_pynvml.nvmlShutdown = Mock()
+    mock_pynvml.nvmlDeviceGetHandleByIndex = Mock(return_value=Mock())
+    nvml_info = Mock()
+    nvml_info.used = 6 * 1024**3
+    nvml_info.free = 10 * 1024**3
+    mock_pynvml.nvmlDeviceGetMemoryInfo = Mock(return_value=nvml_info)
+
+    device_props = Mock()
+    device_props.total_memory = 16 * 1024**3
+
+    with (
+        patch("psutil.virtual_memory", return_value=mock_mem),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.device_count", return_value=1),
+        patch("torch.cuda.memory_allocated", return_value=2 * 1024**3),
+        patch("torch.cuda.memory_reserved", return_value=2 * 1024**3),
+        patch("torch.cuda.get_device_properties", return_value=device_props),
+        patch("torch.cuda.get_device_name", return_value="Mock GPU"),
+        patch("torch.cuda.get_device_capability", return_value=(8, 6)),
+        patch.dict("sys.modules", {"pynvml": mock_pynvml}),
+    ):
+        result = await status_handlers.handle_get_memory_status({})
+
+    gpu_entry = result["gpu_memory"]["gpu_0"]
+    assert "non_torch_gb" in gpu_entry, "expected renamed key `non_torch_gb`"
+    assert "ort_untracked_gb" not in gpu_entry, (
+        "old key `ort_untracked_gb` must not be re-introduced"
+    )
+    # Sanity: non_torch_gb = max(0, nvml_used - torch_allocated) = 6 - 2 = 4.0
+    assert gpu_entry["non_torch_gb"] == 4.0
+
+
+@pytest.mark.asyncio
 async def test_handle_cleanup_resources():
     """Test cleanup_resources calls cleanup function."""
     with patch(

--- a/tools/convert_onnx.py
+++ b/tools/convert_onnx.py
@@ -259,7 +259,8 @@ def convert(
 def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
     """Quality gate: compare PyTorch vs ONNX embeddings.
 
-    Encodes 10 code-like sentences with both backends. Passes if max cosine diff < 0.001
+    Encodes 10 code-like sentences with both backends. Passes if max absolute
+    element-wise diff (on L2-normalised embeddings) < 0.001
     (threshold from the Optimum notebook benchmark: GEMM GELU max diff was 0.0004).
 
     Pooling strategy is read from MODEL_REGISTRY["onnx_pooling"] and must match
@@ -351,10 +352,7 @@ def validate(model_name: str, onnx_dir: Path, device: str = "cpu") -> bool:
         onnx_embeddings = last_hidden[:, 0, :]
     onnx_embeddings = F.normalize(onnx_embeddings.float(), p=2, dim=1)
 
-    # Compute element-wise absolute differences between L2-normalised embeddings.
-    # This is the same metric the Optimum benchmark uses (max diff 0.0004 for
-    # GEMM GELU fusion vs 0.0011 for gelu_approximation), NOT cosine distance —
-    # earlier versions of this log line were mislabelled.
+    # Element-wise |pt - onnx| on L2-normalised embeddings (Optimum benchmark metric).
     diffs = (pt_embeddings.cpu() - onnx_embeddings.cpu()).abs()
     max_diff = float(diffs.max())
     mean_diff = float(diffs.mean())


### PR DESCRIPTION
## Summary

Verified + implemented the actionable findings from the Charlie CI review of the ONNX/VRAM work on \`development\`. Four focused commits; no refactors.

- **e49bbab** — \`onnx_loader.py\`: delete duplicated 54-line provider-options block (only the second copy was wired to \`from_pretrained\`); \`model_loader.py\`: accept \`cuda:N\` in \`_measure_activation_per_item\`; \`convert_onnx.py\`: fix \`validate()\` docstring ("max absolute element-wise diff on L2-normalised embeddings").
- **9e09436** — \`embedder.py\`: \`isinstance(torch.cuda.OutOfMemoryError)\` OOM detection with ORT BFCArena string fallback; dtype-aware \`estimate_activation_gb_from_config\` (fp32 no longer 2× under-estimated); \`status_handlers.py\`: relabel \`ort_untracked_gb\` → \`non_torch_gb\`.
- **45f28f5** — narrow over-broad excepts (drop \`TypeError\`); \`mem_get_info(0)\` consistency; DEBUG log previously-silent excepts; module-level single-GPU assumption note; SESSION_LOG entry for the intentional default-model flip.
- **fd8ab47** (follow-up, addresses CI blocking feedback) — drop the incorrect \`onnx_pooling: "mean"\` entries for BGE-code-v1 (upstream = lasttoken) and CodeRankEmbed (upstream = cls). Add \`onnx_supported: False\` opt-out flag + \`_should_use_onnx\` gate so BGE-code-v1 cannot silently be loaded via ONNX with wrong pooling until lasttoken support lands in the wrapper. Also: explicit parens on dtype expression, new \`non_torch_gb\` key-rename test.

## ⚠️ Breaking rename

\`handle_get_memory_status()\` GPU entries now expose \`non_torch_gb\` instead of \`ort_untracked_gb\`. Any external dashboard/monitor reading the old key will receive \`None\`. The rename is intentional — the old name misleadingly implied the value was ORT-only when the math subtracted per-process PyTorch bytes from device-wide NVML usage, conflating other processes + drivers + ORT.

## Intentionally NOT changed (CI false positives)

- \`_resolve_provider\` already uses \`device.startswith("cuda")\`.
- ONNX fast-path fallback already catches \`ImportError\` AND \`RuntimeError\`.
- \`allow_ram_fallback\` is \`true\` in JSON (CI claimed \`false\`).
- Model switch was Qwen3-Embedding-0.6B → BGE-M3, not gte-modernbert-base → BGE-M3.

## Test plan

- [x] \`pytest tests/unit/ -v\` — all tests pass (added \`test_handle_get_memory_status_gpu_key_rename\`)
- [x] \`ruff check .\` + \`ruff format .\` — clean
- [ ] Smoke: load BGE-M3 via ONNX on CUDA, confirm single \`[ONNX_VRAM] gpu_mem_limit=…\` log line
- [ ] Smoke: \`get_memory_status\` returns \`non_torch_gb\` (not \`ort_untracked_gb\`)
- [ ] Smoke: enable \`use_onnx=True\` with BGE-code-v1 → confirm \`[ONNX] Skipping ... onnx_supported=False\` debug log
- [ ] Charlie CI re-review