### PR TITLE
v0.11.2 hotfix: search-handler concurrency races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.11.2] - 2026-04-19
+
+### Fixed
+
+- **Request-scoped weight overrides no longer race under concurrent search** (`mcp_server/tools/search_handlers.py`, `search/hybrid_searcher.py`, `search/search_executor.py`) — `handle_search_code` previously mutated `searcher.bm25_weight`, `searcher.dense_weight`, and their `SearchExecutor` mirrors before `asyncio.to_thread`; concurrent requests could overwrite each other's intent-driven weights, causing nondeterministic RRF ranking. Weights are now threaded as per-call kwargs from `handle_search_code` → `HybridSearcher.search` → `_single_hop_search` → `SearchExecutor.execute_single_hop` → `RRFReranker.rerank_simple` (which already accepted per-call weights). Instance state is never mutated
+- **`SearchConfig` singleton no longer mutated per request** (`mcp_server/tools/search_handlers.py`) — `get_search_config()` returns a cached process-wide singleton; five sites in `handle_search_code` wrote to `search_config.ego_graph`, `search_config.ego_graph.min_similarity_threshold`, `search_config.parent_retrieval`, `search_config.multi_hop.edge_weights`, and `search_config.ego_graph.edge_weights` at request time. The handler now takes a single `copy.deepcopy` of the singleton before any mutations so all per-request changes stay request-local
+
+---
+
 ## [0.11.1] - 2026-04-18
 
 ### Added

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -34,6 +34,42 @@ This file maintains session memory and context for the Claude-context-MCP semant
 
 ## Session History
 
+### 2026-04-19: v0.11.2 Hotfix — search-handler concurrency races
+
+**Primary Achievement**: Fixed all request-scoped shared-state races in `handle_search_code` flagged by Charlie's second code review of PR #25.
+
+#### Root Cause
+
+`asyncio.to_thread` (added in v0.11.1) removed event-loop serialization of search calls. Two pre-existing mutation patterns became races:
+
+1. **Weight mutations**: `searcher.bm25_weight`, `searcher.dense_weight`, and their `SearchExecutor` mirrors were overwritten with per-request intent weights on a **shared** `HybridSearcher` instance. Concurrent requests could clobber each other's weights between assignment and the `to_thread` call, producing nondeterministic RRF ranking.
+2. **Config singleton mutations**: `get_search_config()` returns a process-wide cached singleton. Five sites in `handle_search_code` wrote to `search_config.ego_graph.*`, `search_config.parent_retrieval`, and `search_config.multi_hop.edge_weights` at request time — all racing with concurrent requests.
+
+#### Fix
+
+- **Weights**: threaded as per-call kwargs (`bm25_weight: float | None`, `dense_weight: float | None`) from `handle_search_code` → `HybridSearcher.search` → `_single_hop_search` → `SearchExecutor.execute_single_hop` → `RRFReranker.rerank_simple` (already accepted per-call weights). Four instance-mutation lines deleted.
+- **Config**: single `copy.deepcopy(get_search_config())` at the top of `handle_search_code`; all five mutation sites now write to the request-local copy. `import copy` added. Global admin path (`configure_search_mode` → `reset_searcher`) unaffected.
+
+#### Tests Added (3)
+
+- `tests/unit/search/test_hybrid_search.py::test_search_accepts_per_call_weights` — confirms weight kwargs propagate to `execute_single_hop` without touching instance attrs
+- `tests/unit/mcp_server/test_search_handlers_isolation.py::test_handle_search_code_does_not_mutate_config_singleton` — exercises all 5 mutation paths, asserts singleton unchanged
+- `tests/fast_integration/test_critical_fixes.py::test_concurrent_search_weight_isolation` — 5 concurrent calls with distinct weights, asserts each `searcher.search` call received its own `(bm25_weight, dense_weight)` pair as kwargs
+
+All 2081 unit + fast-integration tests pass.
+
+#### Files Modified
+
+- `search/search_executor.py` — `execute_single_hop` accepts `bm25_weight` / `dense_weight` kwargs; resolves with `or self.*` fallback
+- `search/hybrid_searcher.py` — same kwargs on `search()` and `_single_hop_search()`; plumbed through
+- `mcp_server/tools/search_handlers.py` — `import copy`; single deepcopy at handler entry; weight kwargs passed to `to_thread`; 4 mutation lines removed
+- `tests/unit/search/test_hybrid_search.py` — 1 new test
+- `tests/unit/mcp_server/test_search_handlers_isolation.py` — new file, 1 test
+- `tests/fast_integration/test_critical_fixes.py` — 1 new test
+- `CHANGELOG.md`, `SESSION_LOG.md`, `pyproject.toml` — docs + version bump
+
+---
+
 ### 2026-04-18: v0.11.1 Release — concurrent search + embed_queries_batch fixes
 
 **Primary Achievement**: Merged PR #25 (`feat: concurrent search + docs alignment`) into `main` and cut the `v0.11.1` patch release.

--- a/mcp_server/tools/search_handlers.py
+++ b/mcp_server/tools/search_handlers.py
@@ -4,6 +4,7 @@ Handlers for code search, similarity finding, and connection analysis.
 """
 
 import asyncio
+import copy
 import logging
 from typing import Any
 
@@ -940,17 +941,19 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     config_manager = get_config_manager()
     actual_search_mode = config_manager.get_search_mode_for_query(query, search_mode)
 
+    # Deep-copy the config singleton so all per-request mutations are request-local.
+    # get_search_config() returns a cached singleton; mutating it directly races with
+    # concurrent requests. The deep copy is cheap (<1 ms for 12 nested dataclasses).
+    base_config = copy.deepcopy(get_search_config())
+
     # Build SearchConfig with ego-graph settings if enabled
     search_config = None
     if isinstance(searcher, HybridSearcher) and ego_graph_enabled:
-        # Get base config and override ego-graph settings
-        base_config = get_search_config()
         ego_config = EgoGraphConfig(
             enabled=ego_graph_enabled,
             k_hops=ego_graph_k_hops,
             max_neighbors_per_hop=ego_graph_max_neighbors,
         )
-        # Create modified config with ego-graph enabled
         search_config = base_config
         search_config.ego_graph = ego_config
         logger.info(
@@ -962,7 +965,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     # Different query intents benefit from different neighbor precision/recall trade-offs
     if isinstance(searcher, HybridSearcher) and ego_graph_enabled and intent_decision:
         if search_config is None:
-            search_config = get_search_config()
+            search_config = base_config
         _intent_ego_thresholds = {
             "local": 0.25,  # Higher precision for specific symbol lookups
             "global": 0.10,  # Broader coverage for architecture queries
@@ -984,29 +987,23 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
 
     # Build SearchConfig with parent-retrieval settings if enabled
     if isinstance(searcher, HybridSearcher) and include_parent:
-        # Get base config if not already set
         if search_config is None:
-            search_config = get_search_config()
-        # Override parent-retrieval settings
+            search_config = base_config
         parent_config = ParentRetrievalConfig(enabled=include_parent)
         search_config.parent_retrieval = parent_config
         logger.info("[PARENT_RETRIEVAL] Enabled")
 
-    # Apply intent-driven weight overrides
+    # Apply intent-driven weight overrides (per-request kwargs — no shared-state mutation)
+    suggested_bm25: float | None = None
+    suggested_dense: float | None = None
     if isinstance(searcher, HybridSearcher) and intent_decision:
         suggested_bm25 = intent_decision.suggested_params.get("bm25_weight")
         suggested_dense = intent_decision.suggested_params.get("dense_weight")
         if suggested_bm25 is not None and suggested_dense is not None:
-            orig_bm25, orig_dense = searcher.bm25_weight, searcher.dense_weight
-            searcher.bm25_weight = suggested_bm25
-            searcher.dense_weight = suggested_dense
-            # Propagate weights to SearchExecutor (has its own weight copies)
-            if hasattr(searcher, "search_executor"):
-                searcher.search_executor.bm25_weight = suggested_bm25
-                searcher.search_executor.dense_weight = suggested_dense
             logger.info(
                 f"[INTENT] Weight override for {intent_decision.intent.value}: "
-                f"BM25={orig_bm25:.2f}→{suggested_bm25:.2f}, Dense={orig_dense:.2f}→{suggested_dense:.2f}"
+                f"BM25={searcher.bm25_weight:.2f}→{suggested_bm25:.2f}, "
+                f"Dense={searcher.dense_weight:.2f}→{suggested_dense:.2f}"
             )
 
     # Apply intent-driven edge weights for graph traversal (A1)
@@ -1017,7 +1014,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
         edge_profile = INTENT_EDGE_WEIGHT_PROFILES.get(intent_key)
         if edge_profile:
             if search_config is None:
-                search_config = get_search_config()
+                search_config = base_config
             search_config.multi_hop.edge_weights = edge_profile
             # Also set for ego-graph path (EgoGraphConfig already has edge_weights field)
             if hasattr(search_config, "ego_graph") and search_config.ego_graph:
@@ -1037,6 +1034,8 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
             use_parallel=get_config().performance.use_parallel_search,
             filters=filters if filters else None,
             config=search_config,
+            bm25_weight=suggested_bm25,
+            dense_weight=suggested_dense,
         )
     else:
         context_depth = 1 if include_context else 0
@@ -1061,7 +1060,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     # === Centrality annotation/reranking ===
     centrality_scores = None
     if search_config is None:
-        search_config = get_search_config()
+        search_config = base_config
     graph_config = getattr(search_config, "graph_enhanced", None)
 
     if (

--- a/mcp_server/tools/search_handlers.py
+++ b/mcp_server/tools/search_handlers.py
@@ -23,6 +23,7 @@ from mcp_server.utils.config_helpers import temporary_ram_fallback_off
 from search.config import (
     EgoGraphConfig,
     ParentRetrievalConfig,
+    SearchConfig,
     get_config_manager,
     get_search_config,
 )
@@ -941,14 +942,23 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     config_manager = get_config_manager()
     actual_search_mode = config_manager.get_search_mode_for_query(query, search_mode)
 
-    # Deep-copy the config singleton so all per-request mutations are request-local.
-    # get_search_config() returns a cached singleton; mutating it directly races with
-    # concurrent requests. The deep copy is cheap (<1 ms for 12 nested dataclasses).
-    search_config = copy.deepcopy(get_search_config())
+    # get_search_config() returns a process-wide cached singleton. Requests that
+    # don't apply ego-graph / parent-retrieval / intent-edge overrides can pass the
+    # singleton straight through. Requests that do mutate lazily deep-copy once,
+    # so the singleton is never written and concurrent requests don't race.
+    config_singleton = get_search_config()
+    config_copy: SearchConfig | None = None
+
+    def mutable_config() -> SearchConfig:
+        """Deep-copy the singleton on first call; return the same copy thereafter."""
+        nonlocal config_copy
+        if config_copy is None:
+            config_copy = copy.deepcopy(config_singleton)
+        return config_copy
 
     # Build SearchConfig with ego-graph settings if enabled
     if isinstance(searcher, HybridSearcher) and ego_graph_enabled:
-        search_config.ego_graph = EgoGraphConfig(
+        mutable_config().ego_graph = EgoGraphConfig(
             enabled=ego_graph_enabled,
             k_hops=ego_graph_k_hops,
             max_neighbors_per_hop=ego_graph_max_neighbors,
@@ -978,11 +988,13 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
                 f"[EGO_GRAPH] Intent-adaptive threshold: "
                 f"{intent_decision.intent.value} -> {intent_threshold}"
             )
-        search_config.ego_graph.min_similarity_threshold = intent_threshold
+        mutable_config().ego_graph.min_similarity_threshold = intent_threshold
 
     # Build SearchConfig with parent-retrieval settings if enabled
     if isinstance(searcher, HybridSearcher) and include_parent:
-        search_config.parent_retrieval = ParentRetrievalConfig(enabled=include_parent)
+        mutable_config().parent_retrieval = ParentRetrievalConfig(
+            enabled=include_parent
+        )
         logger.info("[PARENT_RETRIEVAL] Enabled")
 
     # Apply intent-driven weight overrides (per-request kwargs — no shared-state mutation)
@@ -1005,14 +1017,19 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
         intent_key = intent_decision.intent.value  # e.g. "local", "global"
         edge_profile = INTENT_EDGE_WEIGHT_PROFILES.get(intent_key)
         if edge_profile:
-            search_config.multi_hop.edge_weights = edge_profile
+            cfg = mutable_config()
+            cfg.multi_hop.edge_weights = edge_profile
             # Also set for ego-graph path (EgoGraphConfig already has edge_weights field)
-            if hasattr(search_config, "ego_graph") and search_config.ego_graph:
-                search_config.ego_graph.edge_weights = edge_profile
+            if cfg.ego_graph:
+                cfg.ego_graph.edge_weights = edge_profile
             logger.info(
                 f"[INTENT] Edge weight profile set for {intent_key}: "
                 f"calls={edge_profile.get('calls', 'N/A')}, imports={edge_profile.get('imports', 'N/A')}"
             )
+
+    # Hand the copy to downstream only if we actually made one; otherwise the
+    # read-only singleton is safe to share.
+    effective_config = config_copy if config_copy is not None else config_singleton
 
     if isinstance(searcher, HybridSearcher):
         results = await asyncio.to_thread(
@@ -1023,7 +1040,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
             min_bm25_score=0.1,
             use_parallel=get_config().performance.use_parallel_search,
             filters=filters if filters else None,
-            config=search_config,
+            config=effective_config,
             bm25_weight=suggested_bm25,
             dense_weight=suggested_dense,
         )
@@ -1049,7 +1066,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
 
     # === Centrality annotation/reranking ===
     centrality_scores = None
-    graph_config = getattr(search_config, "graph_enhanced", None)
+    graph_config = getattr(effective_config, "graph_enhanced", None)
 
     if (
         graph_config

--- a/mcp_server/tools/search_handlers.py
+++ b/mcp_server/tools/search_handlers.py
@@ -944,18 +944,15 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     # Deep-copy the config singleton so all per-request mutations are request-local.
     # get_search_config() returns a cached singleton; mutating it directly races with
     # concurrent requests. The deep copy is cheap (<1 ms for 12 nested dataclasses).
-    base_config = copy.deepcopy(get_search_config())
+    search_config = copy.deepcopy(get_search_config())
 
     # Build SearchConfig with ego-graph settings if enabled
-    search_config = None
     if isinstance(searcher, HybridSearcher) and ego_graph_enabled:
-        ego_config = EgoGraphConfig(
+        search_config.ego_graph = EgoGraphConfig(
             enabled=ego_graph_enabled,
             k_hops=ego_graph_k_hops,
             max_neighbors_per_hop=ego_graph_max_neighbors,
         )
-        search_config = base_config
-        search_config.ego_graph = ego_config
         logger.info(
             f"[EGO_GRAPH] Enabled with k_hops={ego_graph_k_hops}, "
             f"max_neighbors_per_hop={ego_graph_max_neighbors}"
@@ -964,8 +961,6 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
     # QW5: apply intent-adaptive similarity threshold to ego-graph expansion
     # Different query intents benefit from different neighbor precision/recall trade-offs
     if isinstance(searcher, HybridSearcher) and ego_graph_enabled and intent_decision:
-        if search_config is None:
-            search_config = base_config
         _intent_ego_thresholds = {
             "local": 0.25,  # Higher precision for specific symbol lookups
             "global": 0.10,  # Broader coverage for architecture queries
@@ -987,10 +982,7 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
 
     # Build SearchConfig with parent-retrieval settings if enabled
     if isinstance(searcher, HybridSearcher) and include_parent:
-        if search_config is None:
-            search_config = base_config
-        parent_config = ParentRetrievalConfig(enabled=include_parent)
-        search_config.parent_retrieval = parent_config
+        search_config.parent_retrieval = ParentRetrievalConfig(enabled=include_parent)
         logger.info("[PARENT_RETRIEVAL] Enabled")
 
     # Apply intent-driven weight overrides (per-request kwargs — no shared-state mutation)
@@ -1013,8 +1005,6 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
         intent_key = intent_decision.intent.value  # e.g. "local", "global"
         edge_profile = INTENT_EDGE_WEIGHT_PROFILES.get(intent_key)
         if edge_profile:
-            if search_config is None:
-                search_config = base_config
             search_config.multi_hop.edge_weights = edge_profile
             # Also set for ego-graph path (EgoGraphConfig already has edge_weights field)
             if hasattr(search_config, "ego_graph") and search_config.ego_graph:
@@ -1059,8 +1049,6 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
 
     # === Centrality annotation/reranking ===
     centrality_scores = None
-    if search_config is None:
-        search_config = base_config
     graph_config = getattr(search_config, "graph_enhanced", None)
 
     if (
@@ -1085,7 +1073,12 @@ async def handle_search_code(arguments: dict[str, Any]) -> dict:
             centrality_scores = ranker._get_centrality_scores()
 
             # QW1: pass centrality scores to ego-graph retriever so neighbors
-            # are ranked by architectural importance before truncation
+            # are ranked by architectural importance before truncation.
+            # NOTE(v0.11.2 follow-up): set_centrality_scores mutates shared retriever
+            # state, but centrality is graph-derived (not query-derived), so all
+            # concurrent requests compute the same scores — races here are benign.
+            # If centrality ever becomes query-aware, isolate this via per-request kwargs
+            # the same way bm25_weight/dense_weight were isolated in v0.11.2.
             if (
                 isinstance(searcher, HybridSearcher)
                 and hasattr(searcher, "ego_graph_retriever")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-context-local"
-version = "0.11.1"
+version = "0.11.2"
 description = "Local semantic code search for Claude Code (MCP) using multi-model routing (Qwen3, BGE-M3, CodeRankEmbed), FAISS, and AST/tree-sitter chunking. 100% local embeddings and indexing."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/search/hybrid_searcher.py
+++ b/search/hybrid_searcher.py
@@ -600,6 +600,8 @@ class HybridSearcher(BaseSearcher):
         min_bm25_score: float = 0.0,
         filters: dict[str, Any] | None = None,
         config: Optional["SearchConfig"] = None,
+        bm25_weight: float | None = None,
+        dense_weight: float | None = None,
     ) -> list[SearchResult]:
         """
         Search using configurable approach (hybrid, semantic-only, or BM25-only).
@@ -669,6 +671,8 @@ class HybridSearcher(BaseSearcher):
                 use_parallel=use_parallel,
                 min_bm25_score=min_bm25_score,
                 filters=filters,
+                bm25_weight=bm25_weight,
+                dense_weight=dense_weight,
             )
 
         # Apply ego-graph expansion if enabled
@@ -708,6 +712,8 @@ class HybridSearcher(BaseSearcher):
         min_bm25_score: float = 0.0,
         filters: dict[str, Any] | None = None,
         query_embedding: np.ndarray | None = None,
+        bm25_weight: float | None = None,
+        dense_weight: float | None = None,
     ) -> list[SearchResult]:
         """
         Internal single-hop search implementation (direct query matching).
@@ -734,6 +740,8 @@ class HybridSearcher(BaseSearcher):
             min_bm25_score=min_bm25_score,
             filters=filters,
             query_embedding=query_embedding,
+            bm25_weight=bm25_weight,
+            dense_weight=dense_weight,
         )
 
     def _apply_ego_graph_expansion(

--- a/search/search_executor.py
+++ b/search/search_executor.py
@@ -89,6 +89,8 @@ class SearchExecutor:
         min_bm25_score: float = 0.0,
         filters: dict[str, Any] | None = None,
         query_embedding: np.ndarray | None = None,
+        bm25_weight: float | None = None,
+        dense_weight: float | None = None,
     ) -> list[SearchResult]:
         """
         Execute single-hop search (direct query matching).
@@ -142,16 +144,18 @@ class SearchExecutor:
 
             # Rerank results
             rerank_start = time.time()
+            eff_bm25 = bm25_weight if bm25_weight is not None else self.bm25_weight
+            eff_dense = dense_weight if dense_weight is not None else self.dense_weight
             self._logger.debug(
-                f"[RERANK] Using weights: BM25={self.bm25_weight}, Dense={self.dense_weight}, "
+                f"[RERANK] Using weights: BM25={eff_bm25}, Dense={eff_dense}, "
                 f"BM25_results={len(bm25_results)}, Dense_results={len(dense_results)}"
             )
             final_results = self.reranker.rerank_simple(
                 bm25_results=bm25_results,
                 dense_results=dense_results,
                 max_results=k,
-                bm25_weight=self.bm25_weight,
-                dense_weight=self.dense_weight,
+                bm25_weight=eff_bm25,
+                dense_weight=eff_dense,
             )
             rerank_time = time.time() - rerank_start
             self._logger.debug(

--- a/tests/fast_integration/test_critical_fixes.py
+++ b/tests/fast_integration/test_critical_fixes.py
@@ -103,7 +103,11 @@ async def test_concurrent_search_weight_isolation():
     import threading
 
     from search.config import SearchConfig
-    from search.hybrid_searcher import HybridSearcher
+    from tests.fixtures.mcp_mocks import (
+        make_app_config_mock,
+        make_hybrid_searcher_mock,
+        make_intent_decision_mock,
+    )
 
     n_calls = 5
     # Unique (bm25, dense) per call so we can distinguish them
@@ -115,54 +119,26 @@ async def test_concurrent_search_weight_isolation():
     captured: list[dict] = []
     capture_lock = threading.Lock()
 
-    def make_search_side_effect():
-        """Capture the bm25_weight/dense_weight kwargs on each call to searcher.search."""
+    def capture_search_kwargs(**kwargs):
+        with capture_lock:
+            captured.append(
+                {
+                    "bm25_weight": kwargs.get("bm25_weight"),
+                    "dense_weight": kwargs.get("dense_weight"),
+                }
+            )
+        return []
 
-        def _search(**kwargs):
-            with capture_lock:
-                captured.append(
-                    {
-                        "bm25_weight": kwargs.get("bm25_weight"),
-                        "dense_weight": kwargs.get("dense_weight"),
-                    }
-                )
-            return []
+    mock_searcher = make_hybrid_searcher_mock(search_side_effect=capture_search_kwargs)
 
-        return _search
-
-    mock_searcher = Mock(spec=HybridSearcher)
-    mock_searcher.is_ready = True
-    mock_searcher.bm25_weight = 0.35
-    mock_searcher.dense_weight = 0.65
-    mock_searcher.search = Mock(side_effect=make_search_side_effect())
-
-    mock_faiss = Mock()
-    mock_faiss.ntotal = 100
-    mock_dense_idx = Mock()
-    mock_dense_idx.index = mock_faiss
-    mock_dense_idx.graph_storage = None
-    mock_searcher.dense_index = mock_dense_idx
-
-    # Pre-build IntentDecision mocks (one per call, keyed by query string)
-    def make_intent_decision(bm25: float, dense: float):
-        d = Mock()
-        d.intent = Mock()
-        d.intent.value = "local"
-        d.confidence = 0.95
-        d.reason = "test"
-        d.suggested_params = {
-            "bm25_weight": bm25,
-            "dense_weight": dense,
-            "search_mode": "hybrid",
-        }
-        return d
-
+    # Pre-build IntentDecision mocks (one per query, keyed by query string)
     decisions = {
-        f"query_{i}": make_intent_decision(*weight_pairs[i]) for i in range(n_calls)
+        f"query_{i}": make_intent_decision_mock("local", *weight_pairs[i])
+        for i in range(n_calls)
     }
 
     def classify_side_effect(query):
-        return decisions.get(query, make_intent_decision(0.35, 0.65))
+        return decisions.get(query, make_intent_decision_mock("local", 0.35, 0.65))
 
     with (
         patch(
@@ -181,15 +157,7 @@ async def test_concurrent_search_weight_isolation():
         mock_state.return_value.current_project = "/test"
         mock_state.return_value.searcher = None
 
-        app_cfg = Mock()
-        app_cfg.intent.enabled = True
-        app_cfg.intent.semantic_enabled = False
-        app_cfg.intent.confidence_threshold = 0.0
-        app_cfg.intent.log_classifications = False
-        app_cfg.performance.use_parallel_search = False
-        app_cfg.output.max_context_tokens = 0
-        mock_app_cfg.return_value = app_cfg
-
+        mock_app_cfg.return_value = make_app_config_mock()
         mock_cfg.return_value = SearchConfig()
         mock_cm.return_value.get_search_mode_for_query.return_value = "hybrid"
 

--- a/tests/fast_integration/test_critical_fixes.py
+++ b/tests/fast_integration/test_critical_fixes.py
@@ -89,5 +89,135 @@ async def test_parallel_tool_calls_dont_cause_race_condition():
 # Reason: Starlette's application lifecycle architecturally guarantees initialization order.
 
 
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_concurrent_search_weight_isolation():
+    """handle_search_code passes per-request intent weights as kwargs to searcher.search.
+
+    Verifies the fix for the shared-state race: intent weights must be threaded as
+    per-call kwargs instead of mutating searcher.bm25_weight / searcher.dense_weight.
+
+    Runs N calls with distinct weight pairs, checks that searcher.search received
+    each pair as explicit kwargs (not instance-state mutations).
+    """
+    import threading
+
+    from search.config import SearchConfig
+    from search.hybrid_searcher import HybridSearcher
+
+    n_calls = 5
+    # Unique (bm25, dense) per call so we can distinguish them
+    weight_pairs = [
+        (round(0.1 * (i + 1), 1), round(1 - 0.1 * (i + 1), 1)) for i in range(n_calls)
+    ]
+
+    # Thread-safe capture: store (bm25_weight, dense_weight) kwargs per call index
+    captured: list[dict] = []
+    capture_lock = threading.Lock()
+
+    def make_search_side_effect():
+        """Capture the bm25_weight/dense_weight kwargs on each call to searcher.search."""
+
+        def _search(**kwargs):
+            with capture_lock:
+                captured.append(
+                    {
+                        "bm25_weight": kwargs.get("bm25_weight"),
+                        "dense_weight": kwargs.get("dense_weight"),
+                    }
+                )
+            return []
+
+        return _search
+
+    mock_searcher = Mock(spec=HybridSearcher)
+    mock_searcher.is_ready = True
+    mock_searcher.bm25_weight = 0.35
+    mock_searcher.dense_weight = 0.65
+    mock_searcher.search = Mock(side_effect=make_search_side_effect())
+
+    mock_faiss = Mock()
+    mock_faiss.ntotal = 100
+    mock_dense_idx = Mock()
+    mock_dense_idx.index = mock_faiss
+    mock_dense_idx.graph_storage = None
+    mock_searcher.dense_index = mock_dense_idx
+
+    # Pre-build IntentDecision mocks (one per call, keyed by query string)
+    def make_intent_decision(bm25: float, dense: float):
+        d = Mock()
+        d.intent = Mock()
+        d.intent.value = "local"
+        d.confidence = 0.95
+        d.reason = "test"
+        d.suggested_params = {
+            "bm25_weight": bm25,
+            "dense_weight": dense,
+            "search_mode": "hybrid",
+        }
+        return d
+
+    decisions = {
+        f"query_{i}": make_intent_decision(*weight_pairs[i]) for i in range(n_calls)
+    }
+
+    def classify_side_effect(query):
+        return decisions.get(query, make_intent_decision(0.35, 0.65))
+
+    with (
+        patch(
+            "mcp_server.tools.search_handlers.get_searcher", return_value=mock_searcher
+        ),
+        patch("mcp_server.tools.search_handlers.get_state") as mock_state,
+        patch("mcp_server.tools.search_handlers.get_config") as mock_app_cfg,
+        patch("mcp_server.tools.search_handlers.get_config_manager") as mock_cm,
+        patch("mcp_server.tools.search_handlers.get_search_config") as mock_cfg,
+        patch("mcp_server.tools.search_handlers.IntentClassifier") as mock_ic_cls,
+        patch(
+            "mcp_server.tools.search_handlers._check_auto_reindex",
+            return_value=(False, None),
+        ),
+    ):
+        mock_state.return_value.current_project = "/test"
+        mock_state.return_value.searcher = None
+
+        app_cfg = Mock()
+        app_cfg.intent.enabled = True
+        app_cfg.intent.semantic_enabled = False
+        app_cfg.intent.confidence_threshold = 0.0
+        app_cfg.intent.log_classifications = False
+        app_cfg.performance.use_parallel_search = False
+        app_cfg.output.max_context_tokens = 0
+        mock_app_cfg.return_value = app_cfg
+
+        mock_cfg.return_value = SearchConfig()
+        mock_cm.return_value.get_search_mode_for_query.return_value = "hybrid"
+
+        ic_instance = Mock()
+        ic_instance.classify.side_effect = classify_side_effect
+        mock_ic_cls.return_value = ic_instance
+
+        await asyncio.gather(
+            *[
+                tool_handlers.handle_search_code({"query": f"query_{i}", "k": 3})
+                for i in range(n_calls)
+            ]
+        )
+
+    # Every call must have forwarded its own (bm25_weight, dense_weight) as kwargs
+    assert len(captured) == n_calls, (
+        f"Expected {n_calls} search calls, got {len(captured)}"
+    )
+    captured_pairs = {(c["bm25_weight"], c["dense_weight"]) for c in captured}
+    expected_pairs = set(weight_pairs)
+    assert captured_pairs == expected_pairs, (
+        f"Weight pairs mismatch. Expected {expected_pairs}, got {captured_pairs}. "
+        "This indicates intent weights were not correctly forwarded as per-call kwargs."
+    )
+    # Instance state must remain untouched for all calls
+    assert mock_searcher.bm25_weight == 0.35
+    assert mock_searcher.dense_weight == 0.65
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])

--- a/tests/fixtures/mcp_mocks.py
+++ b/tests/fixtures/mcp_mocks.py
@@ -1,0 +1,73 @@
+"""Mock builders for MCP server handler tests.
+
+Helpers that produce minimal Mock objects passing the type/ready checks in
+mcp_server/tools/search_handlers.py, so race/isolation tests can exercise the
+handler without loading real models or FAISS indexes.
+"""
+
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import Mock
+
+
+def make_hybrid_searcher_mock(
+    *, search_side_effect: Callable[..., Any] | None = None
+) -> Mock:
+    """Build a Mock that passes HybridSearcher.is_ready and dense_index shape checks.
+
+    Args:
+        search_side_effect: Optional callable used as ``.search.side_effect``.
+            When None, ``.search`` returns an empty list.
+    """
+    from search.hybrid_searcher import HybridSearcher
+
+    mock_searcher = Mock(spec=HybridSearcher)
+    mock_searcher.is_ready = True
+    mock_searcher.bm25_weight = 0.35
+    mock_searcher.dense_weight = 0.65
+
+    mock_faiss = Mock()
+    mock_faiss.ntotal = 100
+    mock_dense = Mock()
+    mock_dense.index = mock_faiss
+    mock_dense.graph_storage = None
+    mock_searcher.dense_index = mock_dense
+
+    if search_side_effect is not None:
+        mock_searcher.search = Mock(side_effect=search_side_effect)
+    else:
+        mock_searcher.search = Mock(return_value=[])
+    return mock_searcher
+
+
+def make_intent_decision_mock(
+    intent_value: str = "local",
+    bm25: float = 0.3,
+    dense: float = 0.7,
+    *,
+    confidence: float = 0.95,
+) -> Mock:
+    """Build a Mock shaped like IntentDecision with the given intent + weights."""
+    decision = Mock()
+    decision.intent = Mock()
+    decision.intent.value = intent_value
+    decision.confidence = confidence
+    decision.reason = "test"
+    decision.suggested_params = {
+        "bm25_weight": bm25,
+        "dense_weight": dense,
+        "search_mode": "hybrid",
+    }
+    return decision
+
+
+def make_app_config_mock() -> Mock:
+    """Build a Mock shaped like ApplicationConfig returned by get_config()."""
+    app_cfg = Mock()
+    app_cfg.intent.enabled = True
+    app_cfg.intent.semantic_enabled = False
+    app_cfg.intent.confidence_threshold = 0.0
+    app_cfg.intent.log_classifications = False
+    app_cfg.performance.use_parallel_search = False
+    app_cfg.output.max_context_tokens = 0
+    return app_cfg

--- a/tests/unit/mcp_server/test_search_handlers_isolation.py
+++ b/tests/unit/mcp_server/test_search_handlers_isolation.py
@@ -11,42 +11,11 @@ import pytest
 
 from mcp_server import tool_handlers
 from search.config import SearchConfig
-
-
-def _make_hybrid_searcher_mock():
-    """Return a minimal Mock that passes the HybridSearcher is_ready / type checks."""
-    from search.hybrid_searcher import HybridSearcher
-
-    mock_searcher = Mock(spec=HybridSearcher)
-    mock_searcher.is_ready = True
-    mock_searcher.bm25_weight = 0.35
-    mock_searcher.dense_weight = 0.65
-
-    mock_faiss = Mock()
-    mock_faiss.ntotal = 100
-    mock_dense = Mock()
-    mock_dense.index = mock_faiss
-    mock_dense.graph_storage = None
-    mock_searcher.dense_index = mock_dense
-
-    mock_searcher.search = Mock(return_value=[])
-    return mock_searcher
-
-
-def _make_intent_decision(intent_value: str, bm25: float = 0.3, dense: float = 0.7):
-    """Build a minimal IntentDecision-shaped mock."""
-
-    decision = Mock()
-    decision.intent = Mock()
-    decision.intent.value = intent_value
-    decision.confidence = 0.95
-    decision.reason = "test"
-    decision.suggested_params = {
-        "bm25_weight": bm25,
-        "dense_weight": dense,
-        "search_mode": "hybrid",
-    }
-    return decision
+from tests.fixtures.mcp_mocks import (
+    make_app_config_mock,
+    make_hybrid_searcher_mock,
+    make_intent_decision_mock,
+)
 
 
 @pytest.mark.asyncio
@@ -60,8 +29,8 @@ async def test_handle_search_code_does_not_mutate_config_singleton():
     - intent edge weights (local intent → INTENT_EDGE_WEIGHT_PROFILES["local"])
     - bm25/dense weight override (via suggested_params)
     """
-    mock_searcher = _make_hybrid_searcher_mock()
-    intent_decision = _make_intent_decision("local", bm25=0.7, dense=0.3)
+    mock_searcher = make_hybrid_searcher_mock()
+    intent_decision = make_intent_decision_mock("local", bm25=0.7, dense=0.3)
 
     # Capture the real singleton before the call
     with patch("mcp_server.tools.search_handlers.get_search_config") as mock_get_cfg:
@@ -82,14 +51,7 @@ async def test_handle_search_code_does_not_mutate_config_singleton():
             mock_state.return_value.current_project = "/test"
             mock_state.return_value.searcher = None
 
-            app_cfg = Mock()
-            app_cfg.intent.enabled = True
-            app_cfg.intent.semantic_enabled = False
-            app_cfg.intent.confidence_threshold = 0.0
-            app_cfg.intent.log_classifications = False
-            app_cfg.performance.use_parallel_search = False
-            mock_app_cfg.return_value = app_cfg
-
+            mock_app_cfg.return_value = make_app_config_mock()
             mock_cm.return_value.get_search_mode_for_query.return_value = "hybrid"
 
             ic_instance = Mock()

--- a/tests/unit/mcp_server/test_search_handlers_isolation.py
+++ b/tests/unit/mcp_server/test_search_handlers_isolation.py
@@ -1,0 +1,122 @@
+"""Tests that handle_search_code does not mutate the get_search_config() singleton.
+
+get_search_config() returns a process-wide cached singleton. Any mutation of that
+object races with concurrent requests. The handler must deep-copy before mutating.
+"""
+
+import copy
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_server import tool_handlers
+from search.config import SearchConfig
+
+
+def _make_hybrid_searcher_mock():
+    """Return a minimal Mock that passes the HybridSearcher is_ready / type checks."""
+    from search.hybrid_searcher import HybridSearcher
+
+    mock_searcher = Mock(spec=HybridSearcher)
+    mock_searcher.is_ready = True
+    mock_searcher.bm25_weight = 0.35
+    mock_searcher.dense_weight = 0.65
+
+    mock_faiss = Mock()
+    mock_faiss.ntotal = 100
+    mock_dense = Mock()
+    mock_dense.index = mock_faiss
+    mock_dense.graph_storage = None
+    mock_searcher.dense_index = mock_dense
+
+    mock_searcher.search = Mock(return_value=[])
+    return mock_searcher
+
+
+def _make_intent_decision(intent_value: str, bm25: float = 0.3, dense: float = 0.7):
+    """Build a minimal IntentDecision-shaped mock."""
+
+    decision = Mock()
+    decision.intent = Mock()
+    decision.intent.value = intent_value
+    decision.confidence = 0.95
+    decision.reason = "test"
+    decision.suggested_params = {
+        "bm25_weight": bm25,
+        "dense_weight": dense,
+        "search_mode": "hybrid",
+    }
+    return decision
+
+
+@pytest.mark.asyncio
+async def test_handle_search_code_does_not_mutate_config_singleton():
+    """handle_search_code must not write to the SearchConfig singleton.
+
+    Exercises all 5 mutation-prone code paths:
+    - ego_graph settings (ego_graph_enabled=True)
+    - intent-adaptive ego threshold
+    - parent_retrieval (include_parent=True)
+    - intent edge weights (local intent → INTENT_EDGE_WEIGHT_PROFILES["local"])
+    - bm25/dense weight override (via suggested_params)
+    """
+    mock_searcher = _make_hybrid_searcher_mock()
+    intent_decision = _make_intent_decision("local", bm25=0.7, dense=0.3)
+
+    # Capture the real singleton before the call
+    with patch("mcp_server.tools.search_handlers.get_search_config") as mock_get_cfg:
+        original_cfg = SearchConfig()  # fresh default config
+        mock_get_cfg.return_value = original_cfg
+        snapshot_before = copy.deepcopy(original_cfg)
+
+        with (
+            patch(
+                "mcp_server.tools.search_handlers.get_searcher",
+                return_value=mock_searcher,
+            ),
+            patch("mcp_server.tools.search_handlers.get_state") as mock_state,
+            patch("mcp_server.tools.search_handlers.get_config") as mock_app_cfg,
+            patch("mcp_server.tools.search_handlers.get_config_manager") as mock_cm,
+            patch("mcp_server.tools.search_handlers.IntentClassifier") as mock_ic_cls,
+        ):
+            mock_state.return_value.current_project = "/test"
+            mock_state.return_value.searcher = None
+
+            app_cfg = Mock()
+            app_cfg.intent.enabled = True
+            app_cfg.intent.semantic_enabled = False
+            app_cfg.intent.confidence_threshold = 0.0
+            app_cfg.intent.log_classifications = False
+            app_cfg.performance.use_parallel_search = False
+            mock_app_cfg.return_value = app_cfg
+
+            mock_cm.return_value.get_search_mode_for_query.return_value = "hybrid"
+
+            ic_instance = Mock()
+            ic_instance.classify.return_value = intent_decision
+            mock_ic_cls.return_value = ic_instance
+
+            await tool_handlers.handle_search_code(
+                {
+                    "query": "find all callers of init",
+                    "k": 5,
+                    "ego_graph_enabled": True,
+                    "ego_graph_k_hops": 2,
+                    "include_parent": True,
+                }
+            )
+
+        # Singleton must be byte-for-byte identical to what it was before
+        assert original_cfg.ego_graph.enabled == snapshot_before.ego_graph.enabled
+        assert (
+            original_cfg.ego_graph.min_similarity_threshold
+            == snapshot_before.ego_graph.min_similarity_threshold
+        )
+        assert (
+            original_cfg.parent_retrieval.enabled
+            == snapshot_before.parent_retrieval.enabled
+        )
+        assert (
+            original_cfg.multi_hop.edge_weights
+            == snapshot_before.multi_hop.edge_weights
+        )

--- a/tests/unit/mcp_server/test_search_handlers_isolation.py
+++ b/tests/unit/mcp_server/test_search_handlers_isolation.py
@@ -120,3 +120,7 @@ async def test_handle_search_code_does_not_mutate_config_singleton():
             original_cfg.multi_hop.edge_weights
             == snapshot_before.multi_hop.edge_weights
         )
+        assert (
+            original_cfg.ego_graph.edge_weights
+            == snapshot_before.ego_graph.edge_weights
+        )

--- a/tests/unit/mcp_server/test_search_handlers_isolation.py
+++ b/tests/unit/mcp_server/test_search_handlers_isolation.py
@@ -47,6 +47,10 @@ async def test_handle_search_code_does_not_mutate_config_singleton():
             patch("mcp_server.tools.search_handlers.get_config") as mock_app_cfg,
             patch("mcp_server.tools.search_handlers.get_config_manager") as mock_cm,
             patch("mcp_server.tools.search_handlers.IntentClassifier") as mock_ic_cls,
+            patch(
+                "mcp_server.tools.search_handlers._check_auto_reindex",
+                return_value=(False, None),
+            ),
         ):
             mock_state.return_value.current_project = "/test"
             mock_state.return_value.searcher = None

--- a/tests/unit/search/test_hybrid_search.py
+++ b/tests/unit/search/test_hybrid_search.py
@@ -894,3 +894,62 @@ class TestCallEdgeResolution:
         import shutil
 
         shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+
+@patch("search.hybrid_searcher.CodeIndexManager")
+@patch("search.hybrid_searcher.BM25Index")
+def test_search_accepts_per_call_weights(mock_bm25, mock_dense):
+    """Per-call bm25_weight/dense_weight flow through to SearchExecutor without mutating instance state."""
+    import tempfile
+
+    temp_dir = tempfile.mkdtemp()
+    try:
+        # Make indices appear ready
+        mock_bm25.return_value.is_empty = False
+        mock_dense_inst = Mock()
+        mock_dense_inst.ntotal = 10
+        mock_dense.return_value.index = mock_dense_inst
+
+        searcher = HybridSearcher(temp_dir)
+
+        captured = {}
+
+        def fake_execute(
+            query,
+            k,
+            search_mode,
+            use_parallel,
+            min_bm25_score,
+            filters,
+            query_embedding=None,
+            bm25_weight=None,
+            dense_weight=None,
+        ):
+            captured["bm25_weight"] = bm25_weight
+            captured["dense_weight"] = dense_weight
+            return []
+
+        searcher.search_executor.execute_single_hop = fake_execute
+
+        with patch(
+            "search.hybrid_searcher._get_config_via_service_locator"
+        ) as mock_cfg:
+            cfg = Mock()
+            cfg.multi_hop.enabled = False
+            cfg.ego_graph.enabled = False
+            cfg.parent_retrieval.enabled = False
+            mock_cfg.return_value = cfg
+            searcher.search("test query", bm25_weight=0.9, dense_weight=0.1)
+
+        # Per-call weights forwarded
+        assert captured.get("bm25_weight") == 0.9
+        assert captured.get("dense_weight") == 0.1
+        # Instance state untouched
+        assert searcher.bm25_weight == 0.35
+        assert searcher.dense_weight == 0.65
+        assert searcher.search_executor.bm25_weight == 0.35
+        assert searcher.search_executor.dense_weight == 0.65
+    finally:
+        import shutil
+
+        shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/unit/search/test_hybrid_search.py
+++ b/tests/unit/search/test_hybrid_search.py
@@ -912,24 +912,8 @@ def test_search_accepts_per_call_weights(mock_bm25, mock_dense):
 
         searcher = HybridSearcher(temp_dir)
 
-        captured = {}
-
-        def fake_execute(
-            query,
-            k,
-            search_mode,
-            use_parallel,
-            min_bm25_score,
-            filters,
-            query_embedding=None,
-            bm25_weight=None,
-            dense_weight=None,
-        ):
-            captured["bm25_weight"] = bm25_weight
-            captured["dense_weight"] = dense_weight
-            return []
-
-        searcher.search_executor.execute_single_hop = fake_execute
+        exec_mock = Mock(return_value=[])
+        searcher.search_executor.execute_single_hop = exec_mock
 
         with patch(
             "search.hybrid_searcher._get_config_via_service_locator"
@@ -941,9 +925,11 @@ def test_search_accepts_per_call_weights(mock_bm25, mock_dense):
             mock_cfg.return_value = cfg
             searcher.search("test query", bm25_weight=0.9, dense_weight=0.1)
 
+        exec_mock.assert_called_once()
+        call_kwargs = exec_mock.call_args.kwargs
         # Per-call weights forwarded
-        assert captured.get("bm25_weight") == 0.9
-        assert captured.get("dense_weight") == 0.1
+        assert call_kwargs.get("bm25_weight") == 0.9
+        assert call_kwargs.get("dense_weight") == 0.1
         # Instance state untouched
         assert searcher.bm25_weight == 0.35
         assert searcher.dense_weight == 0.65


### PR DESCRIPTION
## Changes

- 852f884 fix: per-request search config isolation + per-call weight overrides (PR #25 review + scope expansion)

## Branch

`development` -> `main`