### PR TITLE
feat: ONNX position_ids fix + graph-population seam + stage extractions + installer auto-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.2] - 2026-05-26
+
+### Fixed
+
+- **`IndexWriteStage` bound to stale resources after full reindex** (`search/incremental_indexer.py`) — `IndexWriteStage` and `BM25SyncManager` are now rebuilt via `_build_write_pipeline()` immediately after `_release_and_verify_resources()` reassigns `self.embedder`/`self.indexer`. Previously, successive full-reindex passes could silently embed against a released embedder, report `success=True`, and persist a zero-chunk snapshot.
+- **Embedding errors silently swallowed** (`search/index_write_stage.py`) — `run()` now returns `success=False` with the error message when `embed_chunks()` raises; the snapshot is no longer written, preventing a zero-chunk "success" state from corrupting the incremental index.
+- **GPU cache not cleared on embedding failure** (`search/index_write_stage.py`) — `_clear_gpu("FULL_INDEX")` is now called before the early-return on embedding failure, preventing VRAM pressure that could cause immediate OOM on the next retry.
+
+### Refactored
+
+- **`GraphIntegration` shared initializer** (`search/graph_integration.py`) — extracted `_setup_from_storage(storage)` called by both `__init__` and `from_storage()`, eliminating drift risk when `__init__` gains new instance attributes.
+- **`CommunityDetector` import hoisted to module level** (`search/community_stage.py`) — `ImportError` now surfaces at module load instead of being masked as a "community detection failed" warning. Deferred `LanguageChunker` import annotated with circular-import explanation.
+- **`RelationshipEdge`/`RelationshipType` import hoisted to module level** (`search/graph_integration.py`) — removed three per-call inline copies in `add_chunk`, `populate_from_embeddings`, and `build_graph_from_chunks`.
+
+### Changed
+
+- **Embedding model** (`search_config.json`): `Qwen/Qwen3-Embedding-0.6B` (1024-dim) → `Alibaba-NLP/gte-modernbert-base` (768-dim). **Breaking:** existing FAISS indices built at 1024-dim are dimension-incompatible and require a full reindex.
+- **Reranker** (`search_config.json`): `Alibaba-NLP/gte-reranker-modernbert-base` → `jinaai/jina-reranker-v3`; `min_vram_gb` 4.0 → 6.0 (VRAM-verified: 1.12 GB / 8 GB on RTX 4060).
+- **Routing** (`search_config.json`): `multi_model_enabled` false → true; `multi_model_pool` "full" → "lightweight-speed"; `embedding.batch_size` 128 → 64.
+
+---
+
 ## [0.12.1] - 2026-05-25
 
 ### Added

--- a/docs/VERSION_HISTORY.md
+++ b/docs/VERSION_HISTORY.md
@@ -2,15 +2,35 @@
 
 Complete version history and feature timeline for claude-context-local MCP server.
 
-## Current Status: All Features Operational (2026-05-25)
+## Current Status: All Features Operational (2026-05-26)
 
-- **Version**: 0.12.1
+- **Version**: 0.12.2
 - **Status**: Production-ready
 - **Test Coverage**: 2,090 unit tests + 8 integration tests (100% pass rate)
 - **Dependencies**: 124 packages + optional `onnxruntime-gpu` for ONNX backend
 - **SSCG Benchmark**: Best MRR=0.846 (BM25), Hybrid Recall@10=0.833, all modes 13/13 Hit@5
 - **Token Reduction**: 63% (validated benchmark, Mixed approach vs traditional)
-- **Recent**: 0.12.1 — split_block graph edges fixed (+584 relationship edges), ANSI console colors, `CodeRelationshipAnalyzer` moved to search layer, security audit
+- **Recent**: 0.12.2 — stale write-pipeline rebind fix, embedding-failure reporting, GPU cleanup on OOM, `GraphIntegration` shared initializer, config tuned for gte-modernbert + Jina v3
+
+---
+
+## v0.12.2 - Write-Pipeline Stability + Config Tuning (2026-05-26)
+
+Patch release fixing a root-cause stale-reference bug in `IndexWriteStage`, improving OOM recovery, refactoring `GraphIntegration` for long-term safety, and tuning `search_config.json` for 8 GB VRAM machines.
+
+### Fixed
+- **Stale embedder/indexer in `IndexWriteStage`** (`search/incremental_indexer.py`): `_build_write_pipeline()` helper now rebuilds both `IndexWriteStage` and `BM25SyncManager` after every `_release_and_verify_resources()` call — stages can no longer embed against cleaned-up objects.
+- **Embedding failure silently reported as success** (`search/index_write_stage.py`): `run()` returns `success=False` + error message when embedding raises; snapshot is not written, preventing a zero-chunk corrupt state.
+- **GPU cache not freed on OOM** (`search/index_write_stage.py`): `_clear_gpu("FULL_INDEX")` called before embedding-failure early return, avoiding cascading OOM on immediate retry.
+
+### Refactored
+- **`GraphIntegration` shared initializer** (`search/graph_integration.py`): `_setup_from_storage(storage)` called by both `__init__` and `from_storage()` — the two construction paths share one attribute-setting site.
+- **Import hoists** (`search/community_stage.py`, `search/graph_integration.py`): `CommunityDetector` and `RelationshipEdge`/`RelationshipType` moved to module level; `LanguageChunker` import annotated with circular-import reason.
+
+### Changed (breaking config)
+- **Embedding model**: `Qwen/Qwen3-Embedding-0.6B` (1024-dim) → `Alibaba-NLP/gte-modernbert-base` (768-dim). Requires full reindex if upgrading from 1024-dim index.
+- **Reranker**: `gte-reranker-modernbert-base` → `jinaai/jina-reranker-v3`; `min_vram_gb` 4.0 → 6.0.
+- **Routing**: `multi_model_enabled` false → true; pool "full" → "lightweight-speed"; `batch_size` 128 → 64.
 
 ---
 

--- a/docs/adr/0004-scoped-tracing-only-observability.md
+++ b/docs/adr/0004-scoped-tracing-only-observability.md
@@ -93,23 +93,23 @@ Two architecture improvements surfaced during this investigation.
 
 - **Improvement A** — Decompose the `_full_index` god-method
   (`search/incremental_indexer.py:666-978`, ~312 lines, complexity 38) into
-  named pipeline stages. Status: **in progress**.
+  named pipeline stages. Status: **done** (completed in v0.12.1).
   - `SummaryStage` (`search/summary_stage.py`) — **done** (extracted in
     v0.11.10; handles community + module summary generation with the ordering
     constraint documented in its module docstring).
-  - `CommunityStage` (`search/community_stage.py`) — **pending**: encapsulates
+  - `CommunityStage` (`search/community_stage.py`) — **done**: encapsulates
     community detection (build temp graph, Louvain detect, persist
     `community_map`), `SummaryStage` Phase 1 call, community remerge,
     chunk_id regeneration, `SummaryStage` Phase 2 call, and summary append.
     Interface: `CommunityStage(build_graph_fn, regenerate_ids_fn,
     summary_stage).run(all_chunks, project_path, config) -> list[CodeChunk]`.
-  - `IndexWriteStage` (`search/index_write_stage.py`) — **pending**: encapsulates
+  - `IndexWriteStage` (`search/index_write_stage.py`) — **done**: encapsulates
     embedding, index write, snapshot save, BM25 sync, GPU cache clear.
+    `IncrementalIndexResult` now lives here (moved from `incremental_indexer.py`).
     Interface: `IndexWriteStage(embedder, indexer, snapshot_manager, bm25_sync,
     build_metadata_fn, clear_gpu_fn).run(...) -> IncrementalIndexResult`.
-  - After extraction `_full_index` becomes a ~50-line driver: prologue
-    (resource release, DAG build, chunking) → `CommunityStage.run()` →
-    `IndexWriteStage.run()`.
+  - `_full_index` is now a ~14-line driver: prologue (resource release, DAG
+    build, chunking) → `CommunityStage.run()` → `IndexWriteStage.run()`.
   - Sibling candidate: `_refresh_affected_community_summaries:1162-1310`
     (complexity 34) has the same shape and may follow the same treatment.
 

--- a/docs/adr/0004-scoped-tracing-only-observability.md
+++ b/docs/adr/0004-scoped-tracing-only-observability.md
@@ -87,13 +87,32 @@ env vars.
 - When disabled (default), there is zero OTel SDK import and `traced_block`
   returns on a single boolean check.
 
-## Documented findings (not implemented here)
+## Documented findings
 
-Two architecture improvements surfaced during this investigation. They should
-become their own PRs, informed by latency data from OTel:
+Two architecture improvements surfaced during this investigation.
 
-- **Improvement A** — Extract a named `SummaryStage` from the ~300-line
-  `_full_index` god-method (`search/incremental_indexer.py:596`).
-- **Improvement B** — Close the incremental community-summary gap: the
-  incremental path skips community summaries claiming no `community_map`,
-  but `graph/graph_storage.py:819 load_community_map()` now exists.
+- **Improvement A** — Decompose the `_full_index` god-method
+  (`search/incremental_indexer.py:666-978`, ~312 lines, complexity 38) into
+  named pipeline stages. Status: **in progress**.
+  - `SummaryStage` (`search/summary_stage.py`) — **done** (extracted in
+    v0.11.10; handles community + module summary generation with the ordering
+    constraint documented in its module docstring).
+  - `CommunityStage` (`search/community_stage.py`) — **pending**: encapsulates
+    community detection (build temp graph, Louvain detect, persist
+    `community_map`), `SummaryStage` Phase 1 call, community remerge,
+    chunk_id regeneration, `SummaryStage` Phase 2 call, and summary append.
+    Interface: `CommunityStage(build_graph_fn, regenerate_ids_fn,
+    summary_stage).run(all_chunks, project_path, config) -> list[CodeChunk]`.
+  - `IndexWriteStage` (`search/index_write_stage.py`) — **pending**: encapsulates
+    embedding, index write, snapshot save, BM25 sync, GPU cache clear.
+    Interface: `IndexWriteStage(embedder, indexer, snapshot_manager, bm25_sync,
+    build_metadata_fn, clear_gpu_fn).run(...) -> IncrementalIndexResult`.
+  - After extraction `_full_index` becomes a ~50-line driver: prologue
+    (resource release, DAG build, chunking) → `CommunityStage.run()` →
+    `IndexWriteStage.run()`.
+  - Sibling candidate: `_refresh_affected_community_summaries:1162-1310`
+    (complexity 34) has the same shape and may follow the same treatment.
+
+- **Improvement B** — Close the incremental community-summary gap. Status:
+  **done** (closed in v0.11.10): `incremental_indexer.py:1199` now calls
+  `load_community_map()` from `graph/graph_storage.py:819`.

--- a/embeddings/embedder.py
+++ b/embeddings/embedder.py
@@ -995,6 +995,55 @@ class CodeEmbedder:
 
         return "\n".join(content_parts)
 
+    @staticmethod
+    def _build_chunk_id(chunk: CodeChunk) -> str:
+        """Build the unique chunk identifier from a CodeChunk."""
+        normalized_path = normalize_path(str(chunk.relative_path))
+        chunk_id = (
+            f"{normalized_path}:{chunk.start_line}-{chunk.end_line}:{chunk.chunk_type}"
+        )
+        qualified_name = (
+            f"{chunk.parent_name}.{chunk.name}"
+            if chunk.parent_name and chunk.name
+            else chunk.name
+        )
+        if qualified_name:
+            chunk_id += f":{qualified_name}"
+        return chunk_id
+
+    @staticmethod
+    def _build_chunk_metadata(chunk: CodeChunk) -> dict[str, Any]:
+        """Build the metadata dict for an EmbeddingResult from a CodeChunk."""
+        return {
+            "file_path": chunk.file_path,
+            "relative_path": chunk.relative_path,
+            "folder_structure": chunk.folder_structure,
+            "chunk_type": chunk.chunk_type,
+            "start_line": chunk.start_line,
+            "end_line": chunk.end_line,
+            "name": chunk.name,
+            "parent_name": chunk.parent_name,
+            "parent_chunk_id": chunk.parent_chunk_id,
+            "docstring": chunk.docstring,
+            "decorators": chunk.decorators,
+            "imports": chunk.imports,
+            "complexity_score": chunk.complexity_score,
+            "tags": chunk.tags,
+            "content": chunk.content,  # Full content for accurate token counting
+            "content_preview": (
+                chunk.content[:200] + "..."
+                if len(chunk.content) > 200
+                else chunk.content
+            ),
+            "calls": ([call.to_dict() for call in chunk.calls] if chunk.calls else []),
+            "relationships": (
+                [rel.to_dict() for rel in chunk.relationships]
+                if chunk.relationships
+                else []
+            ),
+            "language": getattr(chunk, "language", "python"),
+        }
+
     def embed_chunk(self, chunk: CodeChunk) -> EmbeddingResult:
         """Generate embedding for a single code chunk."""
         content = self.create_embedding_content(chunk)
@@ -1021,52 +1070,8 @@ class CodeEmbedder:
         if torch and torch.is_tensor(embedding):
             embedding = embedding.cpu().float().numpy()
 
-        # Create unique chunk ID with normalized path separators
-        normalized_path = normalize_path(str(chunk.relative_path))
-        chunk_id = (
-            f"{normalized_path}:{chunk.start_line}-{chunk.end_line}:{chunk.chunk_type}"
-        )
-        # Build qualified name for methods/functions inside classes
-        qualified_name = (
-            f"{chunk.parent_name}.{chunk.name}"
-            if chunk.parent_name and chunk.name
-            else chunk.name
-        )
-        if qualified_name:
-            chunk_id += f":{qualified_name}"
-
-        # Prepare metadata
-        metadata = {
-            "file_path": chunk.file_path,
-            "relative_path": chunk.relative_path,
-            "folder_structure": chunk.folder_structure,
-            "chunk_type": chunk.chunk_type,
-            "start_line": chunk.start_line,
-            "end_line": chunk.end_line,
-            "name": chunk.name,
-            "parent_name": chunk.parent_name,
-            "parent_chunk_id": chunk.parent_chunk_id,
-            "docstring": chunk.docstring,
-            "decorators": chunk.decorators,
-            "imports": chunk.imports,
-            "complexity_score": chunk.complexity_score,
-            "tags": chunk.tags,
-            "content": chunk.content,  # Full content for accurate token counting
-            "content_preview": (
-                chunk.content[:200] + "..."
-                if len(chunk.content) > 200
-                else chunk.content
-            ),
-            # Call graph data
-            "calls": [call.to_dict() for call in chunk.calls] if chunk.calls else [],
-            # Relationship edges
-            "relationships": (
-                [rel.to_dict() for rel in chunk.relationships]
-                if chunk.relationships
-                else []
-            ),
-            "language": getattr(chunk, "language", "python"),
-        }
+        chunk_id = self._build_chunk_id(chunk)
+        metadata = self._build_chunk_metadata(chunk)
 
         return EmbeddingResult(
             embedding=embedding, chunk_id=chunk_id, metadata=metadata
@@ -1357,53 +1362,8 @@ class CodeEmbedder:
                 for _j, (chunk, embedding) in enumerate(
                     zip(batch, batch_embeddings, strict=False)
                 ):
-                    # Normalize path separators for cross-platform consistency
-                    normalized_path = normalize_path(str(chunk.relative_path))
-                    chunk_id = f"{normalized_path}:{chunk.start_line}-{chunk.end_line}:{chunk.chunk_type}"
-                    # Build qualified name for methods/functions inside classes
-                    qualified_name = (
-                        f"{chunk.parent_name}.{chunk.name}"
-                        if chunk.parent_name and chunk.name
-                        else chunk.name
-                    )
-                    if qualified_name:
-                        chunk_id += f":{qualified_name}"
-
-                    metadata = {
-                        "file_path": chunk.file_path,
-                        "relative_path": chunk.relative_path,
-                        "folder_structure": chunk.folder_structure,
-                        "chunk_type": chunk.chunk_type,
-                        "start_line": chunk.start_line,
-                        "end_line": chunk.end_line,
-                        "name": chunk.name,
-                        "parent_name": chunk.parent_name,
-                        "parent_chunk_id": chunk.parent_chunk_id,
-                        "docstring": chunk.docstring,
-                        "decorators": chunk.decorators,
-                        "imports": chunk.imports,
-                        "complexity_score": chunk.complexity_score,
-                        "tags": chunk.tags,
-                        "content": chunk.content,  # Full content for accurate token counting
-                        "content_preview": (
-                            chunk.content[:200] + "..."
-                            if len(chunk.content) > 200
-                            else chunk.content
-                        ),
-                        # Call graph data (Python)
-                        "calls": (
-                            [call.to_dict() for call in chunk.calls]
-                            if chunk.calls
-                            else []
-                        ),
-                        # Relationship edges (all relationship types)
-                        "relationships": (
-                            [rel.to_dict() for rel in chunk.relationships]
-                            if chunk.relationships
-                            else []
-                        ),
-                        "language": getattr(chunk, "language", "python"),
-                    }
+                    chunk_id = self._build_chunk_id(chunk)
+                    metadata = self._build_chunk_metadata(chunk)
 
                     results.append(
                         EmbeddingResult(

--- a/embeddings/onnx_wrapper.py
+++ b/embeddings/onnx_wrapper.py
@@ -120,6 +120,18 @@ class ONNXEmbeddingModel:
             return_tensors="pt",
         )
 
+        # optimum 2.x synthesizes token_type_ids but NOT position_ids; decoder-family
+        # embedding exports (e.g. Qwen3) declare position_ids, so supply it here or
+        # IO binding crashes on None.shape when iterating self.input_names.
+        if (
+            "position_ids" in self.ort_model.input_names
+            and "position_ids" not in encoded
+        ):
+            mask = encoded["attention_mask"]
+            position_ids = mask.long().cumsum(-1) - 1
+            position_ids = position_ids.masked_fill(mask == 0, 1)
+            encoded["position_ids"] = position_ids
+
         # Move to target device
         if target_device == "cuda":
             encoded = {k: v.cuda() for k, v in encoded.items()}

--- a/install-windows.cmd
+++ b/install-windows.cmd
@@ -120,7 +120,11 @@ echo.
 echo === Update/Repair Installation ===
 call :setup_environment
 echo [INFO] Updating all dependencies...
-.venv\Scripts\uv.exe sync
+if "!CUDA_AVAILABLE!"=="1" (
+    .venv\Scripts\uv.exe sync --extra onnx
+) else (
+    .venv\Scripts\uv.exe sync
+)
 if %ERRORLEVEL% neq 0 (
     echo [ERROR] Update failed
     pause
@@ -327,12 +331,14 @@ goto :eof
 :install_cuda_mode
 call :setup_environment
 echo [INFO] CUDA detected. PyTorch cu128 will be installed via uv sync...
+set "INSTALL_ONNX=1"
 call :install_remaining_deps
 goto :eof
 
 :install_cpu_mode
 call :setup_environment
 echo [INFO] CPU-only mode. PyTorch CPU build will be installed via uv sync...
+set "INSTALL_ONNX=0"
 call :install_remaining_deps
 goto :eof
 
@@ -406,8 +412,13 @@ REM EmbeddingGemma is now supported in transformers 5.0+ (no preview needed)
 
 
 
-echo [INFO] Installing all project dependencies...
-".venv\Scripts\uv.exe" sync
+if "!INSTALL_ONNX!"=="1" (
+    echo [INFO] Installing all project dependencies + ONNX/optimum extra ^(GPU^)...
+    ".venv\Scripts\uv.exe" sync --extra onnx
+) else (
+    echo [INFO] Installing all project dependencies...
+    ".venv\Scripts\uv.exe" sync
+)
 if %ERRORLEVEL% neq 0 (
     echo [ERROR] Dependency installation failed
     pause
@@ -455,6 +466,12 @@ echo [INFO] Testing hybrid search dependencies...
 if %ERRORLEVEL% neq 0 (
     echo [ERROR] Hybrid search dependencies test failed
     goto :eof
+)
+
+echo [INFO] Testing ONNX/optimum availability ^(optional^)...
+".venv\Scripts\python.exe" -c "import optimum.onnxruntime, onnxruntime; print('[OK] ONNX runtime + optimum available')" 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo [INFO] ONNX/optimum not installed ^(expected for CPU-only installs^)
 )
 
 echo [INFO] Testing MCP server...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-context-local"
-version = "0.12.1"
+version = "0.12.2"
 description = "Local semantic code search for Claude Code (MCP) using multi-model routing (Qwen3, BGE-M3, CodeRankEmbed), FAISS, and AST/tree-sitter chunking. 100% local embeddings and indexing."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/search/community_stage.py
+++ b/search/community_stage.py
@@ -97,6 +97,8 @@ class CommunityStage:
             logger.info("[COMMUNITY_MERGE] Running community-based remerge")
 
             try:
+                # Deferred import: chunking.languages.base pulls in the chunker stack,
+                # which imports graph modules — importing at module scope creates a cycle.
                 from chunking.languages.base import LanguageChunker
 
                 all_chunks = LanguageChunker.remerge_chunks_with_communities(

--- a/search/community_stage.py
+++ b/search/community_stage.py
@@ -1,0 +1,144 @@
+"""Pipeline stage: community detection, Phase-1 summaries, chunk remerge, Phase-2 summaries."""
+
+import logging
+import traceback
+from collections.abc import Callable
+
+from chunking.python_ast_chunker import CodeChunk
+
+from .config import SearchConfig
+from .graph_integration import GraphIntegration
+from .summary_stage import SummaryStage
+
+
+logger = logging.getLogger(__name__)
+
+
+class CommunityStage:
+    """Pipeline stage encapsulating community detection, community+module summarisation, and remerge.
+
+    Ordering constraint (from SummaryStage): compute_community_summaries must be called with
+    pre-remerge chunk_ids; generate_module_summaries must be called after remerge.
+    """
+
+    def __init__(
+        self,
+        build_graph_fn: Callable[[list[CodeChunk]], GraphIntegration],
+        regenerate_ids_fn: Callable[[list[CodeChunk], str], list[CodeChunk]],
+        summary_stage: SummaryStage,
+    ) -> None:
+        self._build_graph = build_graph_fn
+        self._regenerate_ids = regenerate_ids_fn
+        self._summary_stage = summary_stage
+
+    def run(
+        self,
+        all_chunks: list[CodeChunk],
+        project_path: str,
+        config: SearchConfig,
+    ) -> list[CodeChunk]:
+        """Run community detection, summaries, and remerge.
+
+        Args:
+            all_chunks: Chunks from the chunking pass (pre-remerge).
+            project_path: Absolute path to the indexed project root.
+            config: Current search configuration snapshot.
+
+        Returns:
+            Final chunk list after community remerge and summary injection.
+        """
+        community_map = None
+        temp_graph = None
+
+        # ========== Step A: Community Detection ==========
+        if config.chunking.enable_community_detection and all_chunks:
+            logger.info("[COMMUNITY_DETECT] Running community detection")
+            logger.info(f"[COMMUNITY_DETECT] Starting with {len(all_chunks)} chunks")
+
+            try:
+                temp_graph = self._build_graph(all_chunks)
+
+                from graph.community_detector import CommunityDetector
+
+                # pyrefly: ignore [bad-argument-type]
+                detector = CommunityDetector(temp_graph.storage)
+                community_map = detector.detect_communities(
+                    resolution=config.chunking.community_resolution,
+                    max_phantom_degree=getattr(
+                        config.chunking, "max_phantom_degree", 20
+                    ),
+                )
+                logger.info(
+                    f"[COMMUNITY_DETECT] Detected {len(set(community_map.values()))} communities"
+                    f" from {len(community_map)} nodes"
+                )
+
+                if community_map and temp_graph:
+                    # pyrefly: ignore [missing-attribute]
+                    temp_graph.storage.store_community_map(community_map)
+                    logger.info(
+                        "[COMMUNITY_DETECT] Community map persisted to graph storage"
+                    )
+
+            except Exception as e:
+                logger.error(f"[COMMUNITY_DETECT] Failed: {e}")
+                logger.error(traceback.format_exc())
+                logger.warning("[COMMUNITY_DETECT] Continuing without community data")
+                community_map = None
+
+        # ========== Community Summaries Phase 1: Compute (pre-remerge chunk_ids) ==========
+        community_summaries: list[CodeChunk] = []
+        if config.chunking.enable_community_summaries and community_map and all_chunks:
+            community_summaries = self._summary_stage.compute_community_summaries(
+                all_chunks, community_map, temp_graph
+            )
+
+        # ========== Step B: Community-based Remerge ==========
+        if config.chunking.enable_community_merge and community_map and all_chunks:
+            logger.info("[COMMUNITY_MERGE] Running community-based remerge")
+
+            try:
+                from chunking.languages.base import LanguageChunker
+
+                all_chunks = LanguageChunker.remerge_chunks_with_communities(
+                    chunks=all_chunks,
+                    community_map=community_map,
+                    min_tokens=config.chunking.min_chunk_tokens,
+                    max_merged_tokens=config.chunking.max_merged_tokens,
+                    token_method=config.chunking.token_estimation,
+                    size_method=config.chunking.size_method,
+                )
+                logger.info(
+                    f"[COMMUNITY_MERGE] Community remerge complete: {len(all_chunks)} chunks"
+                )
+
+                all_chunks = self._regenerate_ids(all_chunks, project_path)
+
+                logger.info(
+                    f"[COMMUNITY_MERGE] Community merge complete: {len(all_chunks)} final chunks"
+                )
+
+            except Exception as e:
+                logger.error(f"[COMMUNITY_MERGE] Failed: {e}")
+                logger.error(traceback.format_exc())
+                logger.warning(
+                    "[COMMUNITY_MERGE] Continuing with unmerged chunks from Pass 1"
+                )
+
+        # ========== File-Level Module Summaries (post-remerge) ==========
+        if config.chunking.enable_file_summaries and all_chunks:
+            module_summaries = self._summary_stage.generate_module_summaries(all_chunks)
+            if module_summaries:
+                all_chunks.extend(module_summaries)
+                logger.info(
+                    f"[FILE_SUMMARIES] Appended {len(module_summaries)} module summaries"
+                )
+
+        # ========== Community Summaries Phase 2: Append (post-remerge) ==========
+        if community_summaries:
+            all_chunks.extend(community_summaries)
+            logger.info(
+                f"[COMMUNITY_SUMMARIES] Appended {len(community_summaries)} community summaries"
+            )
+
+        return all_chunks

--- a/search/community_stage.py
+++ b/search/community_stage.py
@@ -5,6 +5,7 @@ import traceback
 from collections.abc import Callable
 
 from chunking.python_ast_chunker import CodeChunk
+from graph.community_detector import CommunityDetector
 
 from .config import SearchConfig
 from .graph_integration import GraphIntegration
@@ -57,8 +58,6 @@ class CommunityStage:
 
             try:
                 temp_graph = self._build_graph(all_chunks)
-
-                from graph.community_detector import CommunityDetector
 
                 # pyrefly: ignore [bad-argument-type]
                 detector = CommunityDetector(temp_graph.storage)

--- a/search/graph_integration.py
+++ b/search/graph_integration.py
@@ -66,8 +66,7 @@ class GraphIntegration:
             project_id: Unique project identifier for graph storage
             storage_dir: Directory where index is stored (graph will be in parent dir)
         """
-        self._logger = logging.getLogger(__name__)
-        self.storage = None
+        self._setup_from_storage(None)
 
         if GRAPH_STORAGE_AVAILABLE and project_id:
             try:
@@ -94,9 +93,18 @@ class GraphIntegration:
             storage: An existing CodeGraphStorage instance, or None.
         """
         instance = cls.__new__(cls)
-        instance._logger = logging.getLogger(__name__)
-        instance.storage = storage
+        instance._setup_from_storage(storage)
         return instance
+
+    def _setup_from_storage(self, storage: Any) -> None:
+        """Set the instance attributes shared by __init__ and from_storage.
+
+        Keeping these in one place ensures the two construction paths never drift:
+        any attribute added here is set whether the instance was built normally or
+        via from_storage()'s cls.__new__ bypass.
+        """
+        self._logger = logging.getLogger(__name__)
+        self.storage = storage
 
     def add_chunk(self, chunk_id: str, metadata: dict[str, Any]) -> None:
         """Add chunk to call graph storage.
@@ -139,6 +147,7 @@ class GraphIntegration:
             self.storage.add_node(
                 chunk_id=chunk_id,
                 name=metadata.get("name", "unknown"),
+                # pyrefly: ignore [bad-argument-type]
                 chunk_type=chunk_type,
                 file_path=metadata.get("file_path", ""),
                 language=metadata.get("language", "python"),

--- a/search/graph_integration.py
+++ b/search/graph_integration.py
@@ -81,6 +81,21 @@ class GraphIntegration:
             except Exception as e:
                 self._logger.warning(f"Failed to initialize graph storage: {e}")
 
+    @classmethod
+    def from_storage(cls, storage: Any) -> "GraphIntegration":
+        """Create a GraphIntegration wrapping an existing CodeGraphStorage instance.
+
+        Use this when the storage was constructed externally (e.g. reused from
+        another manager) and you need a seam handle without re-initialising storage.
+
+        Args:
+            storage: An existing CodeGraphStorage instance, or None.
+        """
+        instance = cls.__new__(cls)
+        instance._logger = logging.getLogger(__name__)
+        instance.storage = storage
+        return instance
+
     def add_chunk(self, chunk_id: str, metadata: dict[str, Any]) -> None:
         """Add chunk to call graph storage.
 
@@ -173,6 +188,114 @@ class GraphIntegration:
 
         except (KeyError, TypeError) as e:
             self._logger.warning(f"Failed to add {chunk_id} to graph: {e}")
+
+    def populate_from_embeddings(self, embedding_results: list[Any]) -> None:
+        """Populate call graph from a list of EmbeddingResult objects.
+
+        Batch two-pass method: builds a symbol-resolution map first, then adds
+        edges using _resolve_call_target (canonical builtins-filter + same-file
+        + split_block disambiguation + qualified-name indexing).
+
+        Incremental-add counterpart to build_graph_from_chunks: does NOT clear
+        the graph first (build_graph_from_chunks clears; this appends).
+
+        Args:
+            embedding_results: List of EmbeddingResult with .chunk_id and .metadata.
+        """
+        if self.storage is None:
+            return
+        if not embedding_results:
+            return
+
+        # === PASS 1: add nodes + build symbol-resolution map ===
+        name_to_chunk_ids: dict[str, list[str]] = defaultdict(list)
+        nodes_added = 0
+
+        for result in embedding_results:
+            chunk_id = result.chunk_id
+            meta = result.metadata
+            chunk_type = meta.get("chunk_type")
+
+            if chunk_type not in SEMANTIC_TYPES:
+                continue
+
+            try:
+                self.storage.add_node(
+                    chunk_id=chunk_id,
+                    name=meta.get("name", "unknown"),
+                    chunk_type=chunk_type,
+                    file_path=meta.get("file_path", ""),
+                    language=meta.get("language", "python"),
+                )
+                nodes_added += 1
+
+                name = meta.get("name")
+                if name:
+                    name_to_chunk_ids[name].append(chunk_id)
+                    if "." in name:
+                        name_to_chunk_ids[name.split(".")[-1]].append(chunk_id)
+                    parent_name = meta.get("parent_name")
+                    if parent_name:
+                        name_to_chunk_ids[f"{parent_name}.{name}"].append(chunk_id)
+
+            except (AttributeError, KeyError, TypeError) as e:
+                self._logger.warning(f"Failed to add node {chunk_id} to graph: {e}")
+
+        # === PASS 2: add call + relationship edges with resolution ===
+        call_edges = 0
+        resolved_edges = 0
+        rel_edges = 0
+
+        for result in embedding_results:
+            chunk_id = result.chunk_id
+            meta = result.metadata
+            caller_file = meta.get("file_path", "")
+
+            for call_dict in meta.get("calls", []):
+                callee_name = call_dict.get("callee_name", "unknown")
+                resolved = self._resolve_call_target(
+                    callee_name, name_to_chunk_ids, caller_file=caller_file
+                )
+                self.storage.add_call_edge(
+                    caller_id=chunk_id,
+                    callee_name=resolved if resolved else callee_name,
+                    line_number=call_dict.get("line_number", 0),
+                    is_method_call=call_dict.get("is_method_call", False),
+                    is_resolved=resolved is not None,
+                )
+                call_edges += 1
+                if resolved:
+                    resolved_edges += 1
+
+            for rel_dict in meta.get("relationships", []):
+                try:
+                    from graph.relationship_types import (
+                        RelationshipEdge,
+                        RelationshipType,
+                    )
+
+                    edge = RelationshipEdge(
+                        source_id=rel_dict.get("source_id", chunk_id),
+                        target_name=rel_dict.get("target_name", "unknown"),
+                        relationship_type=RelationshipType(
+                            rel_dict.get("relationship_type", "calls")
+                        ),
+                        line_number=rel_dict.get("line_number", 0),
+                        confidence=rel_dict.get("confidence", 1.0),
+                        metadata=rel_dict.get("metadata", {}),
+                    )
+                    self.storage.add_relationship_edge(edge)
+                    rel_edges += 1
+                except (ValueError, KeyError, TypeError) as e:
+                    self._logger.debug(
+                        f"Failed to add relationship edge from {chunk_id}: {e}"
+                    )
+
+        self._logger.info(
+            f"Populated graph from embeddings: {nodes_added} nodes, "
+            f"{call_edges} call edges ({resolved_edges} resolved, "
+            f"{call_edges - resolved_edges} phantom), {rel_edges} relationship edges"
+        )
 
     def build_graph_from_chunks(self, chunks) -> None:
         """Build graph from chunks WITHOUT embeddings (for pre-embedding community detection).

--- a/search/graph_integration.py
+++ b/search/graph_integration.py
@@ -15,6 +15,8 @@ except ImportError:
     GRAPH_STORAGE_AVAILABLE = False
     CodeGraphStorage = None
 
+from graph.relationship_types import RelationshipEdge, RelationshipType
+
 
 def is_chunk_id(node_id: str) -> bool:
     """Check if a graph node ID is a real chunk ID (not a bare symbol name).
@@ -160,12 +162,6 @@ class GraphIntegration:
                 )
                 for rel_dict in relationships:
                     try:
-                        # Import RelationshipEdge to reconstruct from dict
-                        from graph.relationship_types import (
-                            RelationshipEdge,
-                            RelationshipType,
-                        )
-
                         # Reconstruct RelationshipEdge from dict
                         edge = RelationshipEdge(
                             source_id=rel_dict.get("source_id", chunk_id),
@@ -232,8 +228,13 @@ class GraphIntegration:
                 name = meta.get("name")
                 if name:
                     name_to_chunk_ids[name].append(chunk_id)
+
+                    # Also index by bare name for methods (ClassName.method → method)
                     if "." in name:
                         name_to_chunk_ids[name.split(".")[-1]].append(chunk_id)
+
+                    # Index qualified name (ClassName.method) for self.method() resolution
+                    # Fixes intra-class method calls by indexing "ClassName.method"
                     parent_name = meta.get("parent_name")
                     if parent_name:
                         name_to_chunk_ids[f"{parent_name}.{name}"].append(chunk_id)
@@ -269,11 +270,6 @@ class GraphIntegration:
 
             for rel_dict in meta.get("relationships", []):
                 try:
-                    from graph.relationship_types import (
-                        RelationshipEdge,
-                        RelationshipType,
-                    )
-
                     edge = RelationshipEdge(
                         source_id=rel_dict.get("source_id", chunk_id),
                         target_name=rel_dict.get("target_name", "unknown"),
@@ -427,12 +423,6 @@ class GraphIntegration:
                 # Add relationship edges
                 for rel in chunk.relationships or []:
                     try:
-                        # Import RelationshipEdge for type handling
-                        from graph.relationship_types import (
-                            RelationshipEdge,
-                            RelationshipType,
-                        )
-
                         # Handle both RelationshipEdge objects and dicts
                         if isinstance(rel, RelationshipEdge):
                             self.storage.add_relationship_edge(rel)

--- a/search/hybrid_searcher.py
+++ b/search/hybrid_searcher.py
@@ -21,11 +21,10 @@ except ImportError:
     torch = None
 
 from graph.graph_storage import CodeGraphStorage
-from graph.relationship_types import RelationshipEdge, RelationshipType
 from mcp_server.utils.config_helpers import (
     get_config_via_service_locator as _get_config_via_service_locator,
 )
-from search.graph_integration import SEMANTIC_TYPES
+from search.graph_integration import GraphIntegration
 from utils.observability import traced_block
 from utils.otel_attributes import (
     ATTR_K,
@@ -262,6 +261,7 @@ class HybridSearcher(BaseSearcher):
         """
         # Initialize to None
         self._graph_storage = None
+        self._graph: GraphIntegration | None = None
         self.ego_graph_retriever = None
 
         if project_id:
@@ -280,6 +280,7 @@ class HybridSearcher(BaseSearcher):
                     self._graph_storage = CodeGraphStorage(
                         project_id=project_id, storage_dir=graph_dir
                     )
+                self._graph = GraphIntegration.from_storage(self._graph_storage)
                 # pyrefly: ignore [bad-argument-type]
                 self.ego_graph_retriever = EgoGraphRetriever(self._graph_storage)
                 self._logger.info(
@@ -291,6 +292,7 @@ class HybridSearcher(BaseSearcher):
                     "Ego-graph expansion will be disabled."
                 )
                 self._graph_storage = None
+                self._graph = None
                 self.ego_graph_retriever = None
 
     def _load_bm25_index(self) -> bool:
@@ -417,6 +419,9 @@ class HybridSearcher(BaseSearcher):
             value: CodeGraphStorage instance or None
         """
         self._graph_storage = value
+        self._graph = (
+            GraphIntegration.from_storage(value) if value is not None else None
+        )
 
     @property
     def stats(self) -> dict[str, Any]:
@@ -1265,132 +1270,9 @@ class HybridSearcher(BaseSearcher):
 
             self.index_documents(documents, doc_ids, embeddings, metadata)
 
-            # Populate call graph with nodes and edges
-            if self._graph_storage is not None:
-                graph_nodes_added = 0
-                graph_edges_added = 0
-                relationship_edges_added = 0
-                resolved_count = 0
-                # Use canonical SEMANTIC_TYPES from graph_integration
-                semantic_types = set(SEMANTIC_TYPES)
-
-                # Build name resolution map for call target resolution
-                # Maps symbol names to their chunk_ids for resolving call targets
-                name_to_chunk_ids: dict[str, list[str]] = {}
-                for result in embedding_results:
-                    chunk_id = result.chunk_id
-                    name = result.metadata.get("name")
-                    if name:
-                        if name not in name_to_chunk_ids:
-                            name_to_chunk_ids[name] = []
-                        name_to_chunk_ids[name].append(chunk_id)
-
-                        # Also index by bare name for methods (ClassName.method → method)
-                        if "." in name:
-                            bare_name = name.split(".")[-1]
-                            if bare_name not in name_to_chunk_ids:
-                                name_to_chunk_ids[bare_name] = []
-                            name_to_chunk_ids[bare_name].append(chunk_id)
-
-                for result in embedding_results:
-                    chunk_id = result.chunk_id
-                    chunk_type = result.metadata.get("chunk_type")
-
-                    # Only add semantic types
-                    if chunk_type not in semantic_types:
-                        continue
-
-                    # Add node
-                    self._graph_storage.add_node(
-                        chunk_id=chunk_id,
-                        name=result.metadata.get("name", "unknown"),
-                        chunk_type=chunk_type,
-                        file_path=result.metadata.get("file_path", ""),
-                        language=result.metadata.get("language", "python"),
-                    )
-                    graph_nodes_added += 1
-
-                    # Add call edges with resolution
-                    calls = result.metadata.get("calls", [])
-                    for call_dict in calls:
-                        callee_name = call_dict.get("callee_name", "unknown")
-
-                        # Try to resolve call target to full chunk_id
-                        # Conservative approach with same-file preference and split_block disambiguation
-                        resolved_target = None
-                        candidates = name_to_chunk_ids.get(callee_name, [])
-                        if len(candidates) == 1:
-                            resolved_target = candidates[0]
-                        elif len(candidates) > 1:
-                            # Same-file preference
-                            caller_file = result.metadata.get("file_path", "")
-                            same_file = [c for c in candidates if caller_file in c]
-                            if len(same_file) == 1:
-                                resolved_target = same_file[0]
-                            else:
-                                # Split block disambiguation: all split_blocks → pick entry block (lowest start line)
-                                split_blocks = [
-                                    c for c in candidates if ":split_block:" in c
-                                ]
-                                if len(split_blocks) == len(candidates):
-
-                                    def _start_line(cid: str) -> int:
-                                        parts = cid.split(":")
-                                        if len(parts) >= 2:
-                                            try:
-                                                return int(parts[1].split("-")[0])
-                                            except (ValueError, IndexError):
-                                                pass
-                                        return 2**31  # Sentinel for sort ordering
-
-                                    split_blocks.sort(key=_start_line)
-                                    resolved_target = split_blocks[0]
-                        if resolved_target:
-                            resolved_count += 1
-
-                        # Use resolved chunk_id if available, otherwise use bare name
-                        self._graph_storage.add_call_edge(
-                            caller_id=chunk_id,
-                            callee_name=(
-                                resolved_target if resolved_target else callee_name
-                            ),
-                            line_number=call_dict.get("line_number", 0),
-                            is_method_call=call_dict.get("is_method_call", False),
-                            is_resolved=resolved_target is not None,
-                        )
-                        graph_edges_added += 1
-
-                    # Add relationship edges (inherits, imports, decorates, etc.)
-                    relationships = result.metadata.get("relationships", [])
-                    for rel_dict in relationships:
-                        try:
-                            # Reconstruct RelationshipEdge from dict
-                            edge = RelationshipEdge(
-                                source_id=rel_dict.get("source_id", chunk_id),
-                                target_name=rel_dict.get("target_name", "unknown"),
-                                relationship_type=RelationshipType(
-                                    rel_dict.get("relationship_type", "calls")
-                                ),
-                                line_number=rel_dict.get("line_number", 0),
-                                confidence=rel_dict.get("confidence", 1.0),
-                                metadata=rel_dict.get("metadata", {}),
-                            )
-
-                            # Add to graph storage
-                            self._graph_storage.add_relationship_edge(edge)
-                            relationship_edges_added += 1
-
-                        except (ValueError, KeyError, TypeError) as e:
-                            self._logger.debug(
-                                f"Failed to add relationship edge from {chunk_id}: {e}"
-                            )
-
-                self._logger.info(
-                    f"[ADD_EMBEDDINGS] Populated graph: {graph_nodes_added} nodes, "
-                    f"{graph_edges_added} call edges ({resolved_count} resolved, "
-                    f"{graph_edges_added - resolved_count} phantom), "
-                    f"{relationship_edges_added} relationship edges"
-                )
+            # Populate call graph via the GraphIntegration seam
+            if self._graph is not None:
+                self._graph.populate_from_embeddings(embedding_results)
 
             self._logger.info(
                 f"[ADD_EMBEDDINGS] Successfully added {len(embedding_results)} embeddings to hybrid index"
@@ -1443,6 +1325,7 @@ class HybridSearcher(BaseSearcher):
         # Update graph_storage reference to match new dense_index (prevents stale references)
         if hasattr(self.dense_index, "_graph") and self.dense_index._graph:
             self._graph_storage = self.dense_index._graph.storage
+            self._graph = GraphIntegration.from_storage(self._graph_storage)
             self._logger.debug(
                 "[CLEAR] Updated graph_storage reference after clear_index()"
             )

--- a/search/incremental_indexer.py
+++ b/search/incremental_indexer.py
@@ -121,13 +121,28 @@ class IncrementalIndexer:
             enable_parallel=self.enable_parallel_chunking,
             max_workers=self.max_chunking_workers,
         )
-        self._bm25_sync = BM25SyncManager(indexer=self.indexer)
         self._summary_stage = SummaryStage()
         self._community_stage = CommunityStage(
             build_graph_fn=self._build_temp_graph,
             regenerate_ids_fn=self._regenerate_chunk_ids,
             summary_stage=self._summary_stage,
         )
+        self._build_write_pipeline()
+        self.precomputed_repo_profile = precomputed_repo_profile
+        self.repo_profile: object | None = (
+            None  # Set after full index for caller capture
+        )
+        self.prebuilt_dag = prebuilt_dag
+        self.built_dag: MerkleDAG | None = None  # Captured for multi-model reuse
+
+    def _build_write_pipeline(self) -> None:
+        """(Re)build the resource-bound write pipeline.
+
+        Call from __init__ and again immediately after _release_and_verify_resources()
+        so IndexWriteStage and BM25SyncManager are always bound to the current
+        self.embedder / self.indexer — never to released objects.
+        """
+        self._bm25_sync = BM25SyncManager(indexer=self.indexer)
         self._index_write_stage = IndexWriteStage(
             embedder=self.embedder,
             indexer=self.indexer,
@@ -136,12 +151,6 @@ class IncrementalIndexer:
             build_metadata_fn=self._build_snapshot_metadata,
             clear_gpu_fn=self._clear_gpu_cache,
         )
-        self.precomputed_repo_profile = precomputed_repo_profile
-        self.repo_profile: object | None = (
-            None  # Set after full index for caller capture
-        )
-        self.prebuilt_dag = prebuilt_dag
-        self.built_dag: MerkleDAG | None = None  # Captured for multi-model reuse
 
     def _get_symbol_cache(self) -> Optional["SymbolHashCache"]:
         """Get symbol cache, handling both CodeIndexManager and HybridSearcher.
@@ -649,6 +658,9 @@ class IncrementalIndexer:
         try:
             # === MANDATORY: Release resources before full reindex ===
             self._release_and_verify_resources(project_path)
+            # Rebind write pipeline to freshly acquired embedder/indexer so the
+            # stage never runs against the released (stale) objects.
+            self._build_write_pipeline()
             # Defense in depth: Load filters from snapshot before deleting it
             # This handles cases where filters weren't passed during IncrementalIndexer creation
             if self.include_dirs is None or self.exclude_dirs is None:

--- a/search/incremental_indexer.py
+++ b/search/incremental_indexer.py
@@ -5,7 +5,6 @@ import logging
 import tempfile
 import time
 import traceback
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -27,8 +26,10 @@ from utils.otel_attributes import (
 from utils.timing import timed
 
 from .bm25_sync import BM25SyncManager
+from .community_stage import CommunityStage
 from .config import get_search_config
 from .graph_integration import GraphIntegration
+from .index_write_stage import IncrementalIndexResult, IndexWriteStage
 from .indexer import CodeIndexManager as Indexer
 from .parallel_chunker import ParallelChunker
 from .summary_stage import SummaryStage
@@ -39,37 +40,6 @@ logger = logging.getLogger(__name__)
 # Minimum GPU memory (MB) considered "still allocated" after cleanup.
 # Below this threshold, residual allocations are expected (PyTorch runtime overhead ~50MB).
 GPU_CLEANUP_THRESHOLD_MB = 100
-
-
-@dataclass
-class IncrementalIndexResult:
-    """Result of incremental indexing operation."""
-
-    files_added: int
-    files_removed: int
-    files_modified: int
-    chunks_added: int
-    chunks_removed: int
-    time_taken: float
-    success: bool
-    error: str | None = None
-    bm25_resynced: bool = False
-    bm25_resync_count: int = 0
-
-    def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary."""
-        return {
-            "files_added": self.files_added,
-            "files_removed": self.files_removed,
-            "files_modified": self.files_modified,
-            "chunks_added": self.chunks_added,
-            "chunks_removed": self.chunks_removed,
-            "time_taken": self.time_taken,
-            "success": self.success,
-            "error": self.error,
-            "bm25_resynced": self.bm25_resynced,
-            "bm25_resync_count": self.bm25_resync_count,
-        }
 
 
 class IncrementalIndexer:
@@ -153,6 +123,19 @@ class IncrementalIndexer:
         )
         self._bm25_sync = BM25SyncManager(indexer=self.indexer)
         self._summary_stage = SummaryStage()
+        self._community_stage = CommunityStage(
+            build_graph_fn=self._build_temp_graph,
+            regenerate_ids_fn=self._regenerate_chunk_ids,
+            summary_stage=self._summary_stage,
+        )
+        self._index_write_stage = IndexWriteStage(
+            embedder=self.embedder,
+            indexer=self.indexer,
+            snapshot_manager=self.snapshot_manager,
+            bm25_sync=self._bm25_sync,
+            build_metadata_fn=self._build_snapshot_metadata,
+            clear_gpu_fn=self._clear_gpu_cache,
+        )
         self.precomputed_repo_profile = precomputed_repo_profile
         self.repo_profile: object | None = (
             None  # Set after full index for caller capture
@@ -776,190 +759,19 @@ class IncrementalIndexer:
 
             logger.info(f"Total chunks collected: {len(all_chunks)}")
 
-            # ========== Community Detection & Remerge ==========
-            # Community merge flow: Chunk → Build graph → Detect communities → (Optional) Remerge → Embed
-            # Community detection runs independently of chunk merging
+            # Stage 1: community detection, summarisation, remerge
             config = get_search_config()
-            community_map = None  # Will be populated if community detection runs
-            temp_graph = None  # Will be set if community detection succeeds
+            all_chunks = self._community_stage.run(all_chunks, project_path, config)
 
-            # Step A: Community Detection (Independent - can run without merging)
-            if config.chunking.enable_community_detection and all_chunks:
-                logger.info("[COMMUNITY_DETECT] Running community detection")
-                logger.info(
-                    f"[COMMUNITY_DETECT] Starting with {len(all_chunks)} chunks"
-                )
-
-                try:
-                    # Build graph from chunks (NetworkX DiGraph)
-                    # Uses GraphIntegration.build_graph_from_chunks() - no embeddings needed
-                    temp_graph = self._build_temp_graph(all_chunks)
-
-                    # Detect communities using native Louvain algorithm
-                    # NetworkX native (no external dependencies: igraph/leidenalg)
-                    from graph.community_detector import CommunityDetector
-
-                    # pyrefly: ignore [bad-argument-type]
-                    detector = CommunityDetector(temp_graph.storage)
-                    community_map = detector.detect_communities(
-                        resolution=config.chunking.community_resolution,
-                        max_phantom_degree=getattr(
-                            config.chunking, "max_phantom_degree", 20
-                        ),
-                    )
-                    logger.info(
-                        f"[COMMUNITY_DETECT] Detected {len(set(community_map.values()))} communities from {len(community_map)} nodes"
-                    )
-
-                    # NEW: Persist community_map to graph storage for future use
-                    if community_map and temp_graph:
-                        # pyrefly: ignore [missing-attribute]
-                        temp_graph.storage.store_community_map(community_map)
-                        logger.info(
-                            "[COMMUNITY_DETECT] Community map persisted to graph storage"
-                        )
-
-                except Exception as e:
-                    logger.error(f"[COMMUNITY_DETECT] Failed: {e}")
-                    logger.error(traceback.format_exc())
-                    logger.warning(
-                        "[COMMUNITY_DETECT] Continuing without community data"
-                    )
-                    community_map = None
-
-            # ========== Community Summaries — PHASE 1: Compute (before remerge) ==========
-            # chunk_ids must match community_map keys, which are pre-remerge.
-            # Phase 2 (append) happens after remerge below; see SummaryStage docstring.
-            community_summaries = []
-            if (
-                config.chunking.enable_community_summaries
-                and community_map
-                and all_chunks
-            ):
-                community_summaries = self._summary_stage.compute_community_summaries(
-                    all_chunks, community_map, temp_graph
-                )
-            # ========== END Community Summaries Phase 1 ==========
-
-            # Step B: Community-based Remerge (Full index only)
-            if config.chunking.enable_community_merge and community_map and all_chunks:
-                logger.info("[COMMUNITY_MERGE] Running community-based remerge")
-
-                try:
-                    # Remerge with community boundaries
-                    # Uses fixed remerge_chunks_with_communities() from base.py
-                    from chunking.languages.base import LanguageChunker
-
-                    all_chunks = LanguageChunker.remerge_chunks_with_communities(
-                        chunks=all_chunks,
-                        community_map=community_map,
-                        min_tokens=config.chunking.min_chunk_tokens,
-                        max_merged_tokens=config.chunking.max_merged_tokens,
-                        token_method=config.chunking.token_estimation,
-                        size_method=config.chunking.size_method,
-                    )
-                    logger.info(
-                        f"[COMMUNITY_MERGE] Community remerge complete: {len(all_chunks)} chunks"
-                    )
-
-                    # Regenerate proper chunk_ids (line numbers changed after merge)
-                    all_chunks = self._regenerate_chunk_ids(all_chunks, project_path)
-
-                    logger.info(
-                        f"[COMMUNITY_MERGE] Community merge complete: {len(all_chunks)} final chunks"
-                    )
-
-                except Exception as e:
-                    logger.error(f"[COMMUNITY_MERGE] Failed: {e}")
-                    logger.error(traceback.format_exc())
-                    logger.warning(
-                        "[COMMUNITY_MERGE] Continuing with unmerged chunks from Pass 1"
-                    )
-            # ========== END Community Detection & Remerge ==========
-
-            # ========== File-Level Module Summaries ==========
-            config = get_search_config()
-            if config.chunking.enable_file_summaries and all_chunks:
-                module_summaries = self._summary_stage.generate_module_summaries(
-                    all_chunks
-                )
-                if module_summaries:
-                    all_chunks.extend(module_summaries)
-                    logger.info(
-                        f"[FILE_SUMMARIES] Appended {len(module_summaries)} module summaries to chunk list"
-                    )
-            # ========== END File-Level Module Summaries ==========
-
-            # ========== Community Summaries — PHASE 2: Append (after remerge) ==========
-            if community_summaries:
-                all_chunks.extend(community_summaries)
-                logger.info(
-                    f"[COMMUNITY_SUMMARIES] Appended {len(community_summaries)} community summaries to chunk list"
-                )
-            # ========== END Community Summaries Phase 2 ==========
-
-            # Embed all chunks in one batched call
-            all_embedding_results = []
-            if all_chunks:
-                try:
-                    logger.info(f"Starting embedding for {len(all_chunks)} chunks")
-                    all_embedding_results = self.embedder.embed_chunks(all_chunks)
-                    logger.info(
-                        f"Successfully embedded {len(all_embedding_results)} chunks"
-                    )
-                    # Update metadata
-                    for chunk, embedding_result in zip(
-                        all_chunks, all_embedding_results, strict=False
-                    ):
-                        embedding_result.metadata["project_name"] = project_name
-                        embedding_result.metadata["content"] = chunk.content
-                except Exception as e:
-                    logger.error(f"Embedding failed: {e}")
-                    logger.error(traceback.format_exc())
-
-            # Add all embeddings to index at once
-            if all_embedding_results:
-                logger.info(f"Adding {len(all_embedding_results)} embeddings to index")
-                self.indexer.add_embeddings(all_embedding_results)
-                logger.info("Successfully added embeddings to index")
-            else:
-                logger.warning("No embedding results to add to index")
-
-            chunks_added = len(all_embedding_results)
-
-            # Save snapshot (reset cumulative_changed_files on full index)
-            metadata = self._build_snapshot_metadata(
-                project_name=project_name,
-                all_files=all_files,
-                supported_files=supported_files,
-                total_chunks=chunks_added,
-                is_full=True,
-                repo_profile=repo_profile,
-                cumulative_changed_files=0,
-            )
-            self.snapshot_manager.save_snapshot(dag, metadata)
-
-            # Save index
-            logger.info("[INCREMENTAL] Saving index...")
-            self.indexer.save_indices()
-            logger.info("[INCREMENTAL] Index saved")
-
-            # Auto-sync BM25 if significant desync detected (>10% difference)
-            bm25_resynced, bm25_resync_count = self._sync_bm25_if_needed("FULL_INDEX")
-
-            # Clear GPU cache to free intermediate tensors from embedding batches
-            self._clear_gpu_cache("FULL_INDEX")
-
-            return IncrementalIndexResult(
-                files_added=len(supported_files),
-                files_removed=0,
-                files_modified=0,
-                chunks_added=chunks_added,
-                chunks_removed=0,
-                time_taken=time.time() - start_time,
-                success=True,
-                bm25_resynced=bm25_resynced,
-                bm25_resync_count=bm25_resync_count,
+            # Stage 2: embed, index, snapshot, BM25, GPU
+            return self._index_write_stage.run(
+                all_chunks,
+                project_name,
+                dag,
+                all_files,
+                supported_files,
+                start_time,
+                self.repo_profile,
             )
 
         except Exception as e:

--- a/search/index_write_stage.py
+++ b/search/index_write_stage.py
@@ -1,0 +1,153 @@
+"""Pipeline stage: embed chunks, write index, save snapshot, sync BM25, clear GPU."""
+
+import logging
+import time
+import traceback
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from chunking.python_ast_chunker import CodeChunk
+from merkle.merkle_dag import MerkleDAG
+from merkle.snapshot_manager import SnapshotManager
+
+from .bm25_sync import BM25SyncManager
+from .indexer import CodeIndexManager as Indexer
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IncrementalIndexResult:
+    """Result of an incremental or full index pass."""
+
+    files_added: int
+    files_removed: int
+    files_modified: int
+    chunks_added: int
+    chunks_removed: int
+    time_taken: float
+    success: bool
+    error: str | None = None
+    bm25_resynced: bool = False
+    bm25_resync_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "files_added": self.files_added,
+            "files_removed": self.files_removed,
+            "files_modified": self.files_modified,
+            "chunks_added": self.chunks_added,
+            "chunks_removed": self.chunks_removed,
+            "time_taken": self.time_taken,
+            "success": self.success,
+            "error": self.error,
+            "bm25_resynced": self.bm25_resynced,
+            "bm25_resync_count": self.bm25_resync_count,
+        }
+
+
+class IndexWriteStage:
+    """Pipeline stage that embeds chunks, writes the FAISS index, saves the snapshot, syncs BM25, and clears GPU cache."""
+
+    def __init__(
+        self,
+        embedder: Any,
+        indexer: Indexer,
+        snapshot_manager: SnapshotManager,
+        bm25_sync: BM25SyncManager,
+        build_metadata_fn: Callable[..., dict[str, Any]],
+        clear_gpu_fn: Callable[[str], None],
+    ) -> None:
+        self._embedder = embedder
+        self._indexer = indexer
+        self._snapshot_manager = snapshot_manager
+        self._bm25_sync = bm25_sync
+        self._build_metadata = build_metadata_fn
+        self._clear_gpu = clear_gpu_fn
+
+    def run(
+        self,
+        all_chunks: list[CodeChunk],
+        project_name: str,
+        dag: MerkleDAG,
+        all_files: list[Any],
+        supported_files: list[Any],
+        start_time: float,
+        repo_profile: object | None,
+    ) -> IncrementalIndexResult:
+        """Embed, index, snapshot, BM25-sync, and GPU-clear for a full index pass.
+
+        Args:
+            all_chunks: Final chunk list after community remerge and summary injection.
+            project_name: Name used to key the snapshot and embedding metadata.
+            dag: Merkle DAG built during this index pass.
+            all_files: All files discovered by the DAG walker.
+            supported_files: Subset of all_files with supported extensions.
+            start_time: Epoch timestamp from the start of the full index pass.
+            repo_profile: Repository profile computed during adaptive sizing, or None.
+
+        Returns:
+            IncrementalIndexResult describing the outcome of the index pass.
+        """
+        # Embed all chunks in one batched call
+        all_embedding_results = []
+        if all_chunks:
+            try:
+                logger.info(f"Starting embedding for {len(all_chunks)} chunks")
+                all_embedding_results = self._embedder.embed_chunks(all_chunks)
+                logger.info(
+                    f"Successfully embedded {len(all_embedding_results)} chunks"
+                )
+                for chunk, embedding_result in zip(
+                    all_chunks, all_embedding_results, strict=False
+                ):
+                    embedding_result.metadata["project_name"] = project_name
+                    embedding_result.metadata["content"] = chunk.content
+            except Exception as e:
+                logger.error(f"Embedding failed: {e}")
+                logger.error(traceback.format_exc())
+
+        # Add all embeddings to index at once
+        if all_embedding_results:
+            logger.info(f"Adding {len(all_embedding_results)} embeddings to index")
+            self._indexer.add_embeddings(all_embedding_results)
+            logger.info("Successfully added embeddings to index")
+        else:
+            logger.warning("No embedding results to add to index")
+
+        chunks_added = len(all_embedding_results)
+
+        # Save snapshot (reset cumulative_changed_files on full index pass)
+        metadata = self._build_metadata(
+            project_name=project_name,
+            all_files=all_files,
+            supported_files=supported_files,
+            total_chunks=chunks_added,
+            is_full=True,
+            repo_profile=repo_profile,
+            cumulative_changed_files=0,
+        )
+        self._snapshot_manager.save_snapshot(dag, metadata)
+
+        logger.info("[INCREMENTAL] Saving index...")
+        self._indexer.save_indices()
+        logger.info("[INCREMENTAL] Index saved")
+
+        bm25_resynced, bm25_resync_count = self._bm25_sync.sync_if_needed("FULL_INDEX")
+
+        self._clear_gpu("FULL_INDEX")
+
+        return IncrementalIndexResult(
+            files_added=len(supported_files),
+            files_removed=0,
+            files_modified=0,
+            chunks_added=chunks_added,
+            chunks_removed=0,
+            time_taken=time.time() - start_time,
+            success=True,
+            bm25_resynced=bm25_resynced,
+            bm25_resync_count=bm25_resync_count,
+        )

--- a/search/index_write_stage.py
+++ b/search/index_write_stage.py
@@ -94,6 +94,7 @@ class IndexWriteStage:
         """
         # Embed all chunks in one batched call
         all_embedding_results = []
+        embed_error: str | None = None
         if all_chunks:
             try:
                 logger.info(f"Starting embedding for {len(all_chunks)} chunks")
@@ -109,6 +110,19 @@ class IndexWriteStage:
             except Exception as e:
                 logger.error(f"Embedding failed: {e}")
                 logger.error(traceback.format_exc())
+                embed_error = str(e)
+
+        if embed_error is not None:
+            return IncrementalIndexResult(
+                files_added=0,
+                files_removed=0,
+                files_modified=0,
+                chunks_added=0,
+                chunks_removed=0,
+                time_taken=time.time() - start_time,
+                success=False,
+                error=embed_error,
+            )
 
         # Add all embeddings to index at once
         if all_embedding_results:

--- a/search/index_write_stage.py
+++ b/search/index_write_stage.py
@@ -113,6 +113,7 @@ class IndexWriteStage:
                 embed_error = str(e)
 
         if embed_error is not None:
+            self._clear_gpu("FULL_INDEX")
             return IncrementalIndexResult(
                 files_added=0,
                 files_removed=0,

--- a/search_config.json
+++ b/search_config.json
@@ -2,7 +2,7 @@
   "embedding": {
     "model_name": "Qwen/Qwen3-Embedding-0.6B",
     "dimension": 1024,
-    "batch_size": 128,
+    "batch_size": 64,
     "query_cache_size": 128,
     "enable_import_context": true,
     "enable_class_context": true,
@@ -51,9 +51,9 @@
     "multi_hop_mode": "hybrid"
   },
   "routing": {
-    "multi_model_enabled": false,
+    "multi_model_enabled": true,
     "default_model": "qwen3_0.6b",
-    "multi_model_pool": "full"
+    "multi_model_pool": "lightweight-speed"
   },
   "intent": {
     "enabled": true,
@@ -65,9 +65,9 @@
   },
   "reranker": {
     "enabled": true,
-    "model_name": "jinaai/jina-reranker-v3",
+    "model_name": "Alibaba-NLP/gte-reranker-modernbert-base",
     "top_k_candidates": 50,
-    "min_vram_gb": 6.0,
+    "min_vram_gb": 4.0,
     "batch_size": 16
   },
   "output": {

--- a/search_config.json
+++ b/search_config.json
@@ -1,7 +1,7 @@
 {
   "embedding": {
-    "model_name": "Qwen/Qwen3-Embedding-0.6B",
-    "dimension": 1024,
+    "model_name": "Alibaba-NLP/gte-modernbert-base",
+    "dimension": 768,
     "batch_size": 64,
     "query_cache_size": 128,
     "enable_import_context": true,
@@ -65,9 +65,9 @@
   },
   "reranker": {
     "enabled": true,
-    "model_name": "Alibaba-NLP/gte-reranker-modernbert-base",
+    "model_name": "jinaai/jina-reranker-v3",
     "top_k_candidates": 50,
-    "min_vram_gb": 4.0,
+    "min_vram_gb": 6.0,
     "batch_size": 16
   },
   "output": {

--- a/tests/unit/embeddings/test_embedder.py
+++ b/tests/unit/embeddings/test_embedder.py
@@ -2038,3 +2038,148 @@ class TestCacheKeyInstructionMode:
         assert encode_count[0] == count_after_prompt, (
             "custom-mode second call must hit the original cache entry"
         )
+
+
+class TestBuildChunkId:
+    """Unit tests for CodeEmbedder._build_chunk_id — no model load required."""
+
+    def _make_chunk(
+        self,
+        relative_path,
+        start_line,
+        end_line,
+        chunk_type,
+        name=None,
+        parent_name=None,
+    ):
+        from unittest.mock import Mock
+
+        chunk = Mock()
+        chunk.relative_path = relative_path
+        chunk.start_line = start_line
+        chunk.end_line = end_line
+        chunk.chunk_type = chunk_type
+        chunk.name = name
+        chunk.parent_name = parent_name
+        return chunk
+
+    def test_basic_function(self):
+        chunk = self._make_chunk("src/foo.py", 10, 20, "function", name="bar")
+        assert CodeEmbedder._build_chunk_id(chunk) == "src/foo.py:10-20:function:bar"
+
+    def test_method_qualified_name(self):
+        chunk = self._make_chunk(
+            "src/foo.py", 5, 15, "method", name="run", parent_name="MyClass"
+        )
+        assert (
+            CodeEmbedder._build_chunk_id(chunk) == "src/foo.py:5-15:method:MyClass.run"
+        )
+
+    def test_no_name_omits_suffix(self):
+        chunk = self._make_chunk(
+            "pkg/mod.py", 1, 50, "module", name=None, parent_name=None
+        )
+        assert CodeEmbedder._build_chunk_id(chunk) == "pkg/mod.py:1-50:module"
+
+    def test_windows_path_normalized(self):
+        chunk = self._make_chunk(
+            "src\\utils\\helper.py", 3, 8, "function", name="do_thing"
+        )
+        result = CodeEmbedder._build_chunk_id(chunk)
+        assert "\\" not in result
+        assert result == "src/utils/helper.py:3-8:function:do_thing"
+
+
+class TestBuildChunkMetadata:
+    """Unit tests for CodeEmbedder._build_chunk_metadata — no model load required."""
+
+    def _make_chunk(self, **kwargs):
+        from unittest.mock import Mock
+
+        defaults = {
+            "file_path": "/abs/src/foo.py",
+            "relative_path": "src/foo.py",
+            "folder_structure": "src",
+            "chunk_type": "function",
+            "start_line": 1,
+            "end_line": 10,
+            "name": "my_func",
+            "parent_name": None,
+            "parent_chunk_id": None,
+            "docstring": "Does a thing.",
+            "decorators": [],
+            "imports": [],
+            "complexity_score": 3,
+            "tags": ["python"],
+            "content": "def my_func(): pass",
+            "calls": [],
+            "relationships": [],
+        }
+        defaults.update(kwargs)
+        chunk = Mock()
+        for k, v in defaults.items():
+            setattr(chunk, k, v)
+        return chunk
+
+    def test_required_keys_present(self):
+        chunk = self._make_chunk()
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        for key in (
+            "file_path",
+            "relative_path",
+            "chunk_type",
+            "start_line",
+            "end_line",
+            "name",
+            "content",
+            "calls",
+            "relationships",
+            "language",
+        ):
+            assert key in meta, f"missing key: {key}"
+
+    def test_language_default(self):
+        chunk = self._make_chunk()
+        del chunk.language  # force getattr fallback
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["language"] == "python"
+
+    def test_language_override(self):
+        chunk = self._make_chunk()
+        chunk.language = "go"
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["language"] == "go"
+
+    def test_content_preview_truncated(self):
+        chunk = self._make_chunk(content="x" * 300)
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["content_preview"].endswith("...")
+        assert len(meta["content_preview"]) == 203  # 200 + "..."
+
+    def test_content_preview_short(self):
+        chunk = self._make_chunk(content="short")
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["content_preview"] == "short"
+
+    def test_calls_serialized(self):
+        from unittest.mock import Mock
+
+        call_mock = Mock()
+        call_mock.to_dict.return_value = {"target": "bar"}
+        chunk = self._make_chunk(calls=[call_mock])
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["calls"] == [{"target": "bar"}]
+
+    def test_empty_calls(self):
+        chunk = self._make_chunk(calls=[])
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["calls"] == []
+
+    def test_relationships_serialized(self):
+        from unittest.mock import Mock
+
+        rel_mock = Mock()
+        rel_mock.to_dict.return_value = {"rel": "imports"}
+        chunk = self._make_chunk(relationships=[rel_mock])
+        meta = CodeEmbedder._build_chunk_metadata(chunk)
+        assert meta["relationships"] == [{"rel": "imports"}]

--- a/tests/unit/embeddings/test_onnx_wrapper.py
+++ b/tests/unit/embeddings/test_onnx_wrapper.py
@@ -198,6 +198,61 @@ class TestONNXEmbeddingModelEncodeReturnType:
         assert isinstance(result, torch.Tensor)
 
 
+class TestONNXPositionIdsInjection:
+    """Regression for optimum 2.x position_ids crash on Qwen3/decoder-family ONNX exports."""
+
+    def _make_ort_with_position_ids(
+        self, batch_size: int = 1, seq_len: int = 8, dim: int = 16
+    ) -> MagicMock:
+        hidden = torch.randn(batch_size, seq_len, dim)
+        output = MagicMock()
+        output.last_hidden_state = hidden
+        ort_model = MagicMock()
+        ort_model.return_value = output
+        # Real dict so `in` check works (unlike MagicMock.__contains__ which returns False)
+        ort_model.input_names = {"input_ids": 0, "attention_mask": 1, "position_ids": 2}
+        return ort_model
+
+    def test_position_ids_injected_when_declared(self):
+        """encode() must supply position_ids when ort_model.input_names declares it."""
+        ort_model = self._make_ort_with_position_ids(batch_size=1, seq_len=6, dim=16)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=6)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        model.encode(["test input"])
+        assert "position_ids" in ort_model.call_args[1]
+
+    def test_position_ids_shape_matches_input_ids(self):
+        """Synthesized position_ids must have same shape as input_ids."""
+        ort_model = self._make_ort_with_position_ids(batch_size=2, seq_len=8, dim=32)
+        tokenizer = _make_tokenizer(batch_size=2, seq_len=8)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        model.encode(["sentence one", "sentence two"])
+        kw = ort_model.call_args[1]
+        assert kw["position_ids"].shape == kw["input_ids"].shape
+
+    def test_position_ids_not_injected_for_encoder_models(self):
+        """Encoder models (BGE-M3, GTE) use MagicMock.input_names — branch must not fire."""
+        ort_model = _make_ort_model(batch_size=1, seq_len=6, dim=16)
+        tokenizer = _make_tokenizer(batch_size=1, seq_len=6)
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        model.encode(["test"])
+        assert "position_ids" not in ort_model.call_args[1]
+
+    def test_position_ids_not_overwritten_when_tokenizer_provides_it(self):
+        """If tokenizer already supplies position_ids, the existing value is preserved."""
+        ort_model = self._make_ort_with_position_ids(batch_size=1, seq_len=6, dim=16)
+        tokenizer = MagicMock()
+        existing = torch.arange(6).unsqueeze(0)
+        tokenizer.return_value = {
+            "input_ids": torch.ones(1, 6, dtype=torch.long),
+            "attention_mask": torch.ones(1, 6, dtype=torch.long),
+            "position_ids": existing,
+        }
+        model = ONNXEmbeddingModel(ort_model, tokenizer, "cpu", "cls")
+        model.encode(["test"])
+        assert torch.equal(ort_model.call_args[1]["position_ids"], existing)
+
+
 class TestONNXEmbeddingModelEncodeDevice:
     def test_encode_cpu_does_not_move_to_cuda(self):
         ort_model = _make_ort_model(batch_size=1, seq_len=4, dim=8)

--- a/tests/unit/search/test_community_stage.py
+++ b/tests/unit/search/test_community_stage.py
@@ -185,8 +185,8 @@ class TestCommunityStageDetectionEnabled:
                 result = stage.run(chunks, "/project", config)
 
         assert community_summary in result
-        # Community summary must be at the end (after module summaries)
-        assert result[-1] == community_summary or community_summary in result
+        # Community summary must be appended last (after module summaries)
+        assert result[-1] == community_summary
 
 
 class TestCommunityStageGracefulDegradation:

--- a/tests/unit/search/test_community_stage.py
+++ b/tests/unit/search/test_community_stage.py
@@ -1,0 +1,241 @@
+"""Unit tests for CommunityStage pipeline stage."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from search.community_stage import CommunityStage
+
+
+def _make_chunk(chunk_id: str = "file.py:1-10:function:foo"):
+    chunk = Mock()
+    chunk.chunk_id = chunk_id
+    chunk.file_path = "file.py"
+    chunk.content = f"def {chunk_id.split(':')[-1]}(): pass"
+    return chunk
+
+
+def _make_config(
+    *,
+    enable_community_detection: bool = True,
+    enable_community_summaries: bool = True,
+    enable_community_merge: bool = True,
+    enable_file_summaries: bool = True,
+    community_resolution: float = 1.0,
+    min_chunk_tokens: int = 20,
+    max_merged_tokens: int = 500,
+    token_estimation: str = "approx",
+    size_method: str = "tokens",
+):
+    config = MagicMock()
+    cfg = config.chunking
+    cfg.enable_community_detection = enable_community_detection
+    cfg.enable_community_summaries = enable_community_summaries
+    cfg.enable_community_merge = enable_community_merge
+    cfg.enable_file_summaries = enable_file_summaries
+    cfg.community_resolution = community_resolution
+    cfg.min_chunk_tokens = min_chunk_tokens
+    cfg.max_merged_tokens = max_merged_tokens
+    cfg.token_estimation = token_estimation
+    cfg.size_method = size_method
+    # getattr fallback for max_phantom_degree
+    cfg.max_phantom_degree = 20
+    return config
+
+
+class TestCommunityStagePassThrough:
+    """When community detection is disabled, chunks pass through unchanged."""
+
+    def test_all_flags_off_returns_original_chunks(self):
+        chunks = [
+            _make_chunk("f.py:1-5:function:a"),
+            _make_chunk("f.py:6-10:function:b"),
+        ]
+        config = _make_config(
+            enable_community_detection=False,
+            enable_community_summaries=False,
+            enable_community_merge=False,
+            enable_file_summaries=False,
+        )
+        stage = CommunityStage(
+            build_graph_fn=Mock(),
+            regenerate_ids_fn=Mock(),
+            summary_stage=Mock(),
+        )
+        result = stage.run(chunks, "/project", config)
+        assert result == chunks
+
+    def test_empty_chunks_returns_empty(self):
+        config = _make_config(enable_community_detection=True)
+        stage = CommunityStage(
+            build_graph_fn=Mock(),
+            regenerate_ids_fn=Mock(),
+            summary_stage=Mock(),
+        )
+        result = stage.run([], "/project", config)
+        assert result == []
+
+
+class TestCommunityStageDetectionEnabled:
+    """Community detection enabled path."""
+
+    def _make_stage_and_mocks(self, community_map=None):
+        chunks = [_make_chunk("f.py:1-5:function:a")]
+        temp_graph = Mock()
+        temp_graph.storage = Mock()
+
+        build_graph_fn = Mock(return_value=temp_graph)
+        regenerate_ids_fn = Mock(side_effect=lambda c, p: c)
+        summary_stage = Mock()
+        summary_stage.compute_community_summaries.return_value = []
+        summary_stage.generate_module_summaries.return_value = []
+
+        stage = CommunityStage(
+            build_graph_fn=build_graph_fn,
+            regenerate_ids_fn=regenerate_ids_fn,
+            summary_stage=summary_stage,
+        )
+        return (
+            stage,
+            chunks,
+            build_graph_fn,
+            regenerate_ids_fn,
+            summary_stage,
+            temp_graph,
+        )
+
+    def test_graph_built_once(self):
+        stage, chunks, build_graph_fn, _, _, _ = self._make_stage_and_mocks()
+        config = _make_config()
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = {
+                "f.py:1-5:function:a": 0
+            }
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.return_value = chunks
+                stage.run(chunks, "/project", config)
+
+        build_graph_fn.assert_called_once_with(chunks)
+
+    def test_community_map_stored_on_graph(self):
+        stage, chunks, _, _, _, temp_graph = self._make_stage_and_mocks()
+        config = _make_config()
+        community_map = {"f.py:1-5:function:a": 0}
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = (
+                community_map
+            )
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.return_value = chunks
+                stage.run(chunks, "/project", config)
+
+        temp_graph.storage.store_community_map.assert_called_once_with(community_map)
+
+    def test_summary_phase1_called_before_remerge(self):
+        """compute_community_summaries must be called with pre-remerge chunks."""
+        stage, chunks, _, _, summary_stage, _ = self._make_stage_and_mocks()
+        config = _make_config()
+        community_map = {"f.py:1-5:function:a": 0}
+        call_order = []
+
+        summary_stage.compute_community_summaries.side_effect = (
+            lambda *a, **kw: call_order.append("phase1") or []
+        )
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = (
+                community_map
+            )
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.side_effect = (
+                    lambda **kw: call_order.append("remerge") or chunks
+                )
+                stage.run(chunks, "/project", config)
+
+        assert call_order.index("phase1") < call_order.index("remerge")
+
+    def test_module_summaries_appended(self):
+        stage, chunks, _, _, summary_stage, _ = self._make_stage_and_mocks()
+        config = _make_config()
+        module_summary = _make_chunk("f.py:module")
+        summary_stage.generate_module_summaries.return_value = [module_summary]
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = {
+                "f.py:1-5:function:a": 0
+            }
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.return_value = chunks
+                result = stage.run(chunks, "/project", config)
+
+        assert module_summary in result
+
+    def test_community_summaries_appended_after_remerge(self):
+        stage, chunks, _, _, summary_stage, _ = self._make_stage_and_mocks()
+        config = _make_config()
+        community_summary = _make_chunk("community:0")
+        summary_stage.compute_community_summaries.return_value = [community_summary]
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = {
+                "f.py:1-5:function:a": 0
+            }
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.return_value = chunks
+                result = stage.run(chunks, "/project", config)
+
+        assert community_summary in result
+        # Community summary must be at the end (after module summaries)
+        assert result[-1] == community_summary or community_summary in result
+
+
+class TestCommunityStageGracefulDegradation:
+    """Community detection failure leaves chunks intact."""
+
+    def test_detection_exception_continues_without_community_data(self):
+        chunks = [_make_chunk("f.py:1-5:function:a")]
+        build_graph_fn = Mock(side_effect=RuntimeError("graph build failed"))
+        summary_stage = Mock()
+        summary_stage.compute_community_summaries.return_value = []
+        summary_stage.generate_module_summaries.return_value = []
+
+        stage = CommunityStage(
+            build_graph_fn=build_graph_fn,
+            regenerate_ids_fn=Mock(),
+            summary_stage=summary_stage,
+        )
+        config = _make_config()
+        result = stage.run(chunks, "/project", config)
+
+        # No exception propagated; chunks unchanged (no remerge without community_map)
+        assert result == chunks
+        summary_stage.compute_community_summaries.assert_not_called()
+
+    def test_remerge_exception_continues_with_unmerged_chunks(self):
+        chunks = [_make_chunk("f.py:1-5:function:a")]
+        temp_graph = Mock()
+        temp_graph.storage = Mock()
+        build_graph_fn = Mock(return_value=temp_graph)
+        summary_stage = Mock()
+        summary_stage.compute_community_summaries.return_value = []
+        summary_stage.generate_module_summaries.return_value = []
+
+        stage = CommunityStage(
+            build_graph_fn=build_graph_fn,
+            regenerate_ids_fn=Mock(),
+            summary_stage=summary_stage,
+        )
+        config = _make_config()
+
+        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+            mock_detector_cls.return_value.detect_communities.return_value = {
+                "f.py:1-5:function:a": 0
+            }
+            with patch("chunking.languages.base.LanguageChunker") as mock_lc:
+                mock_lc.remerge_chunks_with_communities.side_effect = RuntimeError(
+                    "remerge failed"
+                )
+                result = stage.run(chunks, "/project", config)
+
+        # Chunks unchanged; no exception propagated
+        assert result == chunks

--- a/tests/unit/search/test_community_stage.py
+++ b/tests/unit/search/test_community_stage.py
@@ -106,7 +106,7 @@ class TestCommunityStageDetectionEnabled:
         stage, chunks, build_graph_fn, _, _, _ = self._make_stage_and_mocks()
         config = _make_config()
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = {
                 "f.py:1-5:function:a": 0
             }
@@ -121,7 +121,7 @@ class TestCommunityStageDetectionEnabled:
         config = _make_config()
         community_map = {"f.py:1-5:function:a": 0}
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = (
                 community_map
             )
@@ -142,7 +142,7 @@ class TestCommunityStageDetectionEnabled:
             lambda *a, **kw: call_order.append("phase1") or []
         )
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = (
                 community_map
             )
@@ -160,7 +160,7 @@ class TestCommunityStageDetectionEnabled:
         module_summary = _make_chunk("f.py:module")
         summary_stage.generate_module_summaries.return_value = [module_summary]
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = {
                 "f.py:1-5:function:a": 0
             }
@@ -176,7 +176,7 @@ class TestCommunityStageDetectionEnabled:
         community_summary = _make_chunk("community:0")
         summary_stage.compute_community_summaries.return_value = [community_summary]
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = {
                 "f.py:1-5:function:a": 0
             }
@@ -227,7 +227,7 @@ class TestCommunityStageGracefulDegradation:
         )
         config = _make_config()
 
-        with patch("graph.community_detector.CommunityDetector") as mock_detector_cls:
+        with patch("search.community_stage.CommunityDetector") as mock_detector_cls:
             mock_detector_cls.return_value.detect_communities.return_value = {
                 "f.py:1-5:function:a": 0
             }

--- a/tests/unit/search/test_graph_integration.py
+++ b/tests/unit/search/test_graph_integration.py
@@ -275,6 +275,238 @@ class TestGraphIntegration(TestCase):
         # Disambiguation should NOT activate (would return None in real code)
 
 
+class TestFromStorage(TestCase):
+    """Tests for GraphIntegration.from_storage classmethod."""
+
+    def test_from_storage_wraps_existing_storage(self):
+        """from_storage should expose the passed storage as .storage."""
+        mock_storage = Mock()
+        mock_storage.__len__ = Mock(return_value=5)
+
+        graph = GraphIntegration.from_storage(mock_storage)
+
+        self.assertIs(graph.storage, mock_storage)
+        self.assertTrue(graph.is_available)
+        self.assertEqual(len(graph), 5)
+
+    def test_from_storage_none(self):
+        """from_storage(None) should yield an instance with storage=None."""
+        graph = GraphIntegration.from_storage(None)
+
+        self.assertIsNone(graph.storage)
+        self.assertFalse(graph.is_available)
+        self.assertEqual(graph.node_count, 0)
+
+    def test_from_storage_independent_of_init(self):
+        """from_storage should not call CodeGraphStorage constructor."""
+        with patch("search.graph_integration.CodeGraphStorage") as mock_cls:
+            mock_storage = Mock()
+            GraphIntegration.from_storage(mock_storage)
+            mock_cls.assert_not_called()
+
+
+def _make_result(
+    chunk_id: str,
+    chunk_type: str = "function",
+    name: str = "foo",
+    parent_name: str | None = None,
+    calls: list | None = None,
+    relationships: list | None = None,
+    file_path: str = "src/module.py",
+) -> Mock:
+    """Build a mock EmbeddingResult for testing populate_from_embeddings."""
+    result = Mock()
+    result.chunk_id = chunk_id
+    result.metadata = {
+        "chunk_type": chunk_type,
+        "name": name,
+        "parent_name": parent_name,
+        "file_path": file_path,
+        "language": "python",
+        "calls": calls or [],
+        "relationships": relationships or [],
+    }
+    return result
+
+
+class TestPopulateFromEmbeddings(TestCase):
+    """Tests for GraphIntegration.populate_from_embeddings."""
+
+    def _make_graph(self) -> tuple[GraphIntegration, Mock]:
+        storage = Mock()
+        storage.__len__ = Mock(return_value=0)
+        graph = GraphIntegration.from_storage(storage)
+        return graph, storage
+
+    def test_no_storage_is_noop(self):
+        """populate_from_embeddings on a None-storage instance should be silent."""
+        graph = GraphIntegration.from_storage(None)
+        result = _make_result("f.py:1-5:function:foo")
+        graph.populate_from_embeddings([result])  # must not raise
+
+    def test_empty_list_is_noop(self):
+        """Empty embedding_results list should not touch storage."""
+        graph, storage = self._make_graph()
+        graph.populate_from_embeddings([])
+        storage.add_node.assert_not_called()
+        storage.add_call_edge.assert_not_called()
+
+    def test_nodes_added_for_semantic_types(self):
+        """Only semantic-type chunks get nodes; non-semantic types are skipped."""
+        graph, storage = self._make_graph()
+
+        semantic = _make_result(
+            "f.py:1-5:function:do_thing", chunk_type="function", name="do_thing"
+        )
+        non_semantic = _make_result("f.py:6-8:module:f", chunk_type="module")
+
+        graph.populate_from_embeddings([semantic, non_semantic])
+
+        # Exactly one node added (the function, not the module)
+        storage.add_node.assert_called_once_with(
+            chunk_id="f.py:1-5:function:do_thing",
+            name="do_thing",
+            chunk_type="function",
+            file_path="src/module.py",
+            language="python",
+        )
+
+    def test_unique_call_target_resolved(self):
+        """A callee whose name maps to exactly one chunk_id resolves with is_resolved=True."""
+        graph, storage = self._make_graph()
+
+        callee = _make_result("f.py:10-15:function:helper", name="helper")
+        caller = _make_result(
+            "f.py:20-30:function:main",
+            name="main",
+            calls=[
+                {"callee_name": "helper", "line_number": 25, "is_method_call": False}
+            ],
+        )
+
+        graph.populate_from_embeddings([callee, caller])
+
+        call_args = storage.add_call_edge.call_args_list
+        assert len(call_args) == 1
+        kwargs = call_args[0].kwargs
+        self.assertEqual(kwargs["callee_name"], "f.py:10-15:function:helper")
+        self.assertTrue(kwargs["is_resolved"])
+
+    def test_common_method_name_stays_phantom(self):
+        """Calls to common method builtins (get, join, append) must NOT resolve
+        even when a project symbol of the same name exists in the batch.
+        This is the divergence the inline copy had: it lacked _resolve_call_target's
+        common-method filter and would mis-resolve these names."""
+        graph, storage = self._make_graph()
+
+        # A project function named "get" exists in the batch
+        project_get = _make_result("f.py:1-5:function:get", name="get")
+        # A caller that calls "get" (the common dict method)
+        caller = _make_result(
+            "f.py:10-20:function:process",
+            name="process",
+            calls=[{"callee_name": "get", "line_number": 15, "is_method_call": True}],
+        )
+
+        graph.populate_from_embeddings([project_get, caller])
+
+        call_args = storage.add_call_edge.call_args_list
+        assert len(call_args) == 1
+        kwargs = call_args[0].kwargs
+        # Must NOT be resolved to the project "get" function
+        self.assertEqual(kwargs["callee_name"], "get")
+        self.assertFalse(kwargs["is_resolved"])
+
+    def test_qualified_parent_name_resolves_intra_class_calls(self):
+        """Calls to 'ClassName.method' should resolve via the qualified-name index
+        that populate_from_embeddings builds. The inline copy lacked this indexing
+        and would leave intra-class self.method() calls as phantom."""
+        graph, storage = self._make_graph()
+
+        method = _make_result(
+            "c.py:10-20:method:MyClass.process",
+            chunk_type="method",
+            name="process",
+            parent_name="MyClass",
+        )
+        caller = _make_result(
+            "c.py:30-40:method:MyClass.run",
+            chunk_type="method",
+            name="run",
+            parent_name="MyClass",
+            calls=[
+                {
+                    "callee_name": "MyClass.process",
+                    "line_number": 35,
+                    "is_method_call": True,
+                }
+            ],
+        )
+
+        graph.populate_from_embeddings([method, caller])
+
+        call_args = storage.add_call_edge.call_args_list
+        assert len(call_args) == 1
+        kwargs = call_args[0].kwargs
+        self.assertEqual(kwargs["callee_name"], "c.py:10-20:method:MyClass.process")
+        self.assertTrue(kwargs["is_resolved"])
+
+    def test_relationship_edges_added(self):
+        """Relationship edges in metadata should be forwarded to add_relationship_edge."""
+        graph, storage = self._make_graph()
+
+        result = _make_result(
+            "child.py:1-10:class:Child",
+            chunk_type="class",
+            name="Child",
+            relationships=[
+                {
+                    "source_id": "child.py:1-10:class:Child",
+                    "target_name": "Base",
+                    "relationship_type": "inherits",
+                    "line_number": 1,
+                    "confidence": 1.0,
+                    "metadata": {},
+                }
+            ],
+        )
+
+        graph.populate_from_embeddings([result])
+        storage.add_relationship_edge.assert_called_once()
+
+    def test_ambiguous_same_file_preferred(self):
+        """When two candidates share a name, the one in the caller's file is preferred."""
+        graph, storage = self._make_graph()
+
+        local_helper = _make_result(
+            "src/module.py:1-5:function:helper",
+            name="helper",
+            file_path="src/module.py",
+        )
+        other_helper = _make_result(
+            "src/other.py:10-15:function:helper",
+            name="helper",
+            file_path="src/other.py",
+        )
+        caller = _make_result(
+            "src/module.py:20-30:function:main",
+            name="main",
+            file_path="src/module.py",
+            calls=[
+                {"callee_name": "helper", "line_number": 25, "is_method_call": False}
+            ],
+        )
+
+        graph.populate_from_embeddings([local_helper, other_helper, caller])
+
+        call_args = storage.add_call_edge.call_args_list
+        assert len(call_args) == 1
+        kwargs = call_args[0].kwargs
+        # Same-file preference: resolves to local_helper, not other_helper
+        self.assertEqual(kwargs["callee_name"], "src/module.py:1-5:function:helper")
+        self.assertTrue(kwargs["is_resolved"])
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/tests/unit/search/test_incremental_indexer.py
+++ b/tests/unit/search/test_incremental_indexer.py
@@ -603,9 +603,12 @@ class TestIncrementalIndexer:
 
             result = indexer.incremental_index(str(self.project_path), "test_project")
 
-            # Should succeed with zero chunks added
-            assert result.success is True
+            # Embedding failure is reported as a hard failure — no bogus snapshot
+            assert result.success is False
+            assert result.error is not None
+            assert "Embedding failed" in result.error
             assert result.chunks_added == 0
+            self.mock_snapshot_manager.save_snapshot.assert_not_called()
 
     def test_batch_removal_with_validation(self):
         """Test batch removal with index consistency validation."""
@@ -863,6 +866,8 @@ class TestIncrementalIndexer:
             "total_chunks": 100,
         }
         self.mock_indexer.resync_bm25_from_dense = Mock(return_value=100)
+        # Prevent the incremental path from failing at index consistency check
+        self.mock_indexer.validate_index_consistency.return_value = (True, [])
 
         result = indexer.incremental_index(str(self.project_path), "test_project")
 
@@ -1033,6 +1038,52 @@ class TestIncrementalIndexer:
         assert saved_dag.directory_filter is not None
         assert saved_dag.directory_filter.include_dirs == include_dirs
         assert saved_dag.directory_filter.exclude_dirs == exclude_dirs
+
+    @patch.object(IncrementalIndexer, "_release_and_verify_resources")
+    def test_write_pipeline_rebound_after_resource_refresh(self, mock_release):
+        """IndexWriteStage must use the freshly acquired embedder/indexer after
+        _release_and_verify_resources() swaps them in — not the original stale ones."""
+        indexer = IncrementalIndexer(
+            indexer=self.mock_indexer,
+            embedder=self.mock_embedder,
+            chunker=self.mock_chunker,
+            snapshot_manager=self.mock_snapshot_manager,
+        )
+
+        # Simulate _release_and_verify_resources replacing embedder/indexer
+        fresh_embedder = Mock()
+        fresh_embedding_result = Mock()
+        fresh_embedding_result.metadata = {}
+        fresh_embedder.embed_chunks.return_value = [fresh_embedding_result]
+        fresh_indexer = Mock()
+
+        def swap_resources(project_path):
+            indexer.embedder = fresh_embedder
+            indexer.indexer = fresh_indexer
+
+        mock_release.side_effect = swap_resources
+
+        self.mock_snapshot_manager.has_snapshot.return_value = False
+
+        with patch("search.incremental_indexer.MerkleDAG") as mock_dag_class:
+            mock_dag = Mock()
+            mock_dag.get_all_files.return_value = ["main.py"]
+            mock_dag_class.return_value = mock_dag
+
+            mock_chunk = Mock()
+            mock_chunk.content = "test content"
+            self.mock_chunker.is_supported.return_value = True
+            self.mock_chunker.chunk_file.return_value = [mock_chunk]
+
+            result = indexer.incremental_index(str(self.project_path), "test_project")
+
+        assert result.success is True
+        # Fresh embedder must have been used — stale one must NOT
+        fresh_embedder.embed_chunks.assert_called()
+        self.mock_embedder.embed_chunks.assert_not_called()
+        # Fresh indexer received the embeddings — stale one must NOT
+        fresh_indexer.add_embeddings.assert_called()
+        self.mock_indexer.add_embeddings.assert_not_called()
 
     def teardown_method(self):
         """Clean up test fixtures."""

--- a/tests/unit/search/test_index_write_stage.py
+++ b/tests/unit/search/test_index_write_stage.py
@@ -1,0 +1,309 @@
+"""Unit tests for IndexWriteStage pipeline stage."""
+
+import time
+from unittest.mock import Mock
+
+from search.index_write_stage import IncrementalIndexResult, IndexWriteStage
+
+
+def _make_chunk(chunk_id: str = "file.py:1-10:function:foo"):
+    chunk = Mock()
+    chunk.chunk_id = chunk_id
+    chunk.content = "def foo(): pass"
+    return chunk
+
+
+def _make_stage(
+    *,
+    embed_results=None,
+    bm25_result=(False, 0),
+):
+    embedder = Mock()
+    if embed_results is None:
+        embed_result = Mock()
+        embed_result.metadata = {}
+        embed_results = [embed_result]
+    embedder.embed_chunks.return_value = embed_results
+
+    indexer = Mock()
+    snapshot_manager = Mock()
+    bm25_sync = Mock()
+    bm25_sync.sync_if_needed.return_value = bm25_result
+    build_metadata_fn = Mock(return_value={"project_name": "test"})
+    clear_gpu_fn = Mock()
+    dag = Mock()
+
+    stage = IndexWriteStage(
+        embedder=embedder,
+        indexer=indexer,
+        snapshot_manager=snapshot_manager,
+        bm25_sync=bm25_sync,
+        build_metadata_fn=build_metadata_fn,
+        clear_gpu_fn=clear_gpu_fn,
+    )
+    return (
+        stage,
+        embedder,
+        indexer,
+        snapshot_manager,
+        bm25_sync,
+        build_metadata_fn,
+        clear_gpu_fn,
+        dag,
+    )
+
+
+class TestIndexWriteStageResult:
+    """Verify IncrementalIndexResult fields on success."""
+
+    def test_successful_run_returns_correct_result(self):
+        chunk = _make_chunk()
+        embed_result = Mock()
+        embed_result.metadata = {}
+        stage, _, _, _, _, _, _, dag = _make_stage(embed_results=[embed_result])
+
+        start = time.time()
+        result = stage.run(
+            all_chunks=[chunk],
+            project_name="myproject",
+            dag=dag,
+            all_files=["a.py", "b.py"],
+            supported_files=["a.py"],
+            start_time=start,
+            repo_profile=None,
+        )
+
+        assert isinstance(result, IncrementalIndexResult)
+        assert result.success is True
+        assert result.error is None
+        assert result.files_added == 1  # len(supported_files)
+        assert result.files_removed == 0
+        assert result.files_modified == 0
+        assert result.chunks_added == 1
+        assert result.chunks_removed == 0
+        assert result.time_taken >= 0
+
+    def test_bm25_flags_propagated(self):
+        chunk = _make_chunk()
+        embed_result = Mock()
+        embed_result.metadata = {}
+        stage, *_, dag = _make_stage(
+            embed_results=[embed_result], bm25_result=(True, 42)
+        )
+
+        result = stage.run(
+            all_chunks=[chunk],
+            project_name="p",
+            dag=dag,
+            all_files=[],
+            supported_files=[],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        assert result.bm25_resynced is True
+        assert result.bm25_resync_count == 42
+
+    def test_files_added_equals_len_supported_files(self):
+        embed_result = Mock()
+        embed_result.metadata = {}
+        stage, *_, dag = _make_stage(embed_results=[embed_result])
+        supported = ["a.py", "b.py", "c.py"]
+
+        result = stage.run(
+            all_chunks=[_make_chunk()],
+            project_name="p",
+            dag=dag,
+            all_files=supported + ["untracked.txt"],
+            supported_files=supported,
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        assert result.files_added == 3
+
+
+class TestIndexWriteStageOrdering:
+    """Embed → add → snapshot → save_indices → bm25 → gpu must happen in that order."""
+
+    def test_call_order(self):
+        call_order = []
+        chunk = _make_chunk()
+        embed_result = Mock()
+        embed_result.metadata = {}
+
+        embedder = Mock()
+        embedder.embed_chunks.side_effect = lambda *a, **kw: call_order.append(
+            "embed"
+        ) or [embed_result]
+        indexer = Mock()
+        indexer.add_embeddings.side_effect = lambda *a, **kw: call_order.append("add")
+        indexer.save_indices.side_effect = lambda *a, **kw: call_order.append(
+            "save_indices"
+        )
+        snapshot_manager = Mock()
+        snapshot_manager.save_snapshot.side_effect = lambda *a, **kw: call_order.append(
+            "save_snapshot"
+        )
+        bm25_sync = Mock()
+        bm25_sync.sync_if_needed.side_effect = lambda *a, **kw: call_order.append(
+            "bm25"
+        ) or (False, 0)
+        clear_gpu_fn = Mock(side_effect=lambda *a, **kw: call_order.append("gpu"))
+
+        stage = IndexWriteStage(
+            embedder=embedder,
+            indexer=indexer,
+            snapshot_manager=snapshot_manager,
+            bm25_sync=bm25_sync,
+            build_metadata_fn=Mock(return_value={}),
+            clear_gpu_fn=clear_gpu_fn,
+        )
+        stage.run(
+            all_chunks=[chunk],
+            project_name="p",
+            dag=Mock(),
+            all_files=[],
+            supported_files=[],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        assert call_order == [
+            "embed",
+            "add",
+            "save_snapshot",
+            "save_indices",
+            "bm25",
+            "gpu",
+        ]
+
+    def test_snapshot_metadata_passes_is_full_true(self):
+        embed_result = Mock()
+        embed_result.metadata = {}
+        stage, _, _, _, _, build_metadata_fn, _, dag = _make_stage(
+            embed_results=[embed_result]
+        )
+
+        stage.run(
+            all_chunks=[_make_chunk()],
+            project_name="proj",
+            dag=dag,
+            all_files=["f.py"],
+            supported_files=["f.py"],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        call_kwargs = build_metadata_fn.call_args.kwargs
+        assert call_kwargs["is_full"] is True
+        assert call_kwargs["cumulative_changed_files"] == 0
+        assert call_kwargs["project_name"] == "proj"
+
+    def test_embedding_metadata_updated(self):
+        chunk = _make_chunk("f.py:1-5:function:foo")
+        chunk.content = "def foo(): pass"
+        embed_result = Mock()
+        embed_result.metadata = {}
+        stage, *_, dag = _make_stage(embed_results=[embed_result])
+
+        stage.run(
+            all_chunks=[chunk],
+            project_name="myproj",
+            dag=dag,
+            all_files=[],
+            supported_files=[],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        assert embed_result.metadata["project_name"] == "myproj"
+        assert embed_result.metadata["content"] == "def foo(): pass"
+
+
+class TestIndexWriteStageGracefulDegradation:
+    """Embedding failure degrades gracefully."""
+
+    def test_embedding_failure_produces_zero_chunks_added(self):
+        embedder = Mock()
+        embedder.embed_chunks.side_effect = RuntimeError("CUDA OOM")
+        indexer = Mock()
+        snapshot_manager = Mock()
+        bm25_sync = Mock()
+        bm25_sync.sync_if_needed.return_value = (False, 0)
+
+        stage = IndexWriteStage(
+            embedder=embedder,
+            indexer=indexer,
+            snapshot_manager=snapshot_manager,
+            bm25_sync=bm25_sync,
+            build_metadata_fn=Mock(return_value={}),
+            clear_gpu_fn=Mock(),
+        )
+
+        result = stage.run(
+            all_chunks=[_make_chunk()],
+            project_name="p",
+            dag=Mock(),
+            all_files=[],
+            supported_files=[],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        assert result.chunks_added == 0
+        indexer.add_embeddings.assert_not_called()
+
+    def test_empty_chunks_skips_embed_and_add(self):
+        stage, embedder, indexer, *_ = _make_stage()
+
+        result = stage.run(
+            all_chunks=[],
+            project_name="p",
+            dag=Mock(),
+            all_files=[],
+            supported_files=[],
+            start_time=time.time(),
+            repo_profile=None,
+        )
+
+        embedder.embed_chunks.assert_not_called()
+        indexer.add_embeddings.assert_not_called()
+        assert result.chunks_added == 0
+
+
+class TestIncrementalIndexResultDataclass:
+    """Verify IncrementalIndexResult fields and to_dict."""
+
+    def test_defaults(self):
+        r = IncrementalIndexResult(
+            files_added=1,
+            files_removed=0,
+            files_modified=0,
+            chunks_added=10,
+            chunks_removed=0,
+            time_taken=0.5,
+            success=True,
+        )
+        assert r.error is None
+        assert r.bm25_resynced is False
+        assert r.bm25_resync_count == 0
+
+    def test_to_dict_round_trip(self):
+        r = IncrementalIndexResult(
+            files_added=3,
+            files_removed=1,
+            files_modified=2,
+            chunks_added=30,
+            chunks_removed=10,
+            time_taken=2.0,
+            success=False,
+            error="boom",
+            bm25_resynced=True,
+            bm25_resync_count=5,
+        )
+        d = r.to_dict()
+        assert d["files_added"] == 3
+        assert d["error"] == "boom"
+        assert d["bm25_resynced"] is True
+        assert d["bm25_resync_count"] == 5

--- a/tests/unit/search/test_index_write_stage.py
+++ b/tests/unit/search/test_index_write_stage.py
@@ -221,10 +221,10 @@ class TestIndexWriteStageOrdering:
         assert embed_result.metadata["content"] == "def foo(): pass"
 
 
-class TestIndexWriteStageGracefulDegradation:
-    """Embedding failure degrades gracefully."""
+class TestIndexWriteStageEmbeddingFailure:
+    """Embedding failure is reported loudly: success=False, no snapshot written."""
 
-    def test_embedding_failure_produces_zero_chunks_added(self):
+    def test_embedding_failure_returns_failure_result(self):
         embedder = Mock()
         embedder.embed_chunks.side_effect = RuntimeError("CUDA OOM")
         indexer = Mock()
@@ -251,8 +251,12 @@ class TestIndexWriteStageGracefulDegradation:
             repo_profile=None,
         )
 
+        assert result.success is False
+        assert result.error is not None
+        assert "CUDA OOM" in result.error
         assert result.chunks_added == 0
         indexer.add_embeddings.assert_not_called()
+        snapshot_manager.save_snapshot.assert_not_called()
 
     def test_empty_chunks_skips_embed_and_add(self):
         stage, embedder, indexer, *_ = _make_stage()

--- a/tests/unit/search/test_index_write_stage.py
+++ b/tests/unit/search/test_index_write_stage.py
@@ -231,6 +231,7 @@ class TestIndexWriteStageEmbeddingFailure:
         snapshot_manager = Mock()
         bm25_sync = Mock()
         bm25_sync.sync_if_needed.return_value = (False, 0)
+        clear_gpu_fn = Mock()
 
         stage = IndexWriteStage(
             embedder=embedder,
@@ -238,7 +239,7 @@ class TestIndexWriteStageEmbeddingFailure:
             snapshot_manager=snapshot_manager,
             bm25_sync=bm25_sync,
             build_metadata_fn=Mock(return_value={}),
-            clear_gpu_fn=Mock(),
+            clear_gpu_fn=clear_gpu_fn,
         )
 
         result = stage.run(
@@ -257,6 +258,7 @@ class TestIndexWriteStageEmbeddingFailure:
         assert result.chunks_added == 0
         indexer.add_embeddings.assert_not_called()
         snapshot_manager.save_snapshot.assert_not_called()
+        clear_gpu_fn.assert_called_once_with("FULL_INDEX")
 
     def test_empty_chunks_skips_embed_and_add(self):
         stage, embedder, indexer, *_ = _make_stage()


### PR DESCRIPTION
## Changes

- 6f2f3bf refactor: share GraphIntegration init across from_storage; comment deferred import; tighten community-summary ordering test
- 9664bd5 fix: rebind index-write pipeline to refreshed resources; report embedding failure
- 7b6f90c chore: install ONNX/optimum extra in CUDA mode via installer
- 94524c8 fix: supply position_ids to ONNX encode for optimum 2.x (Qwen3)
- 14e7ac3 refactor: route HybridSearcher graph population through GraphIntegration seam (Candidate C)
- 709d852 refactor: extract _build_chunk_id and _build_chunk_metadata staticmethods in CodeEmbedder
- 8eee26f docs: mark ADR-0004 Improvement A as done (CommunityStage + IndexWriteStage extracted)
- eac0eab refactor: extract CommunityStage and IndexWriteStage from _full_index god-method

## ⚠️ Breaking config changes

`search_config.json` was updated to tune for an 8 GB VRAM machine. Two of these changes are **breaking** — consumers upgrading from `main` need a full reindex.

| Setting | Old (main) | New | Notes |
|---|---|---|---|
| `embedding.model_name` | `Qwen/Qwen3-Embedding-0.6B` | `Alibaba-NLP/gte-modernbert-base` | **Breaking** — 1024-dim → 768-dim; existing FAISS index is dimension-incompatible, must full-reindex |
| `embedding.batch_size` | 128 | 64 | Prevents VRAM exhaustion on 8 GB GPU during batch embed |
| `multi_model_enabled` | false | true | Enable multi-model routing (required for pool below) |
| `multi_model_pool` | full | lightweight-speed | Light pool: routes query traffic to smaller models, preserving VRAM headroom |
| `reranker.model_name` | `Alibaba-NLP/gte-reranker-modernbert-base` | `jinaai/jina-reranker-v3` | **Breaking** — different model, different VRAM budget |
| `reranker.min_vram_gb` | 4.0 | 6.0 | Raised to match Jina v3 actual usage |

> Reranker VRAM verified: Jina v3 + gte-modernbert lightweight pool = **1.12 GB allocated / 1.95 GB reserved** on RTX 4060 8 GB (14% utilization). Config is intentionally machine-specific.

## Behavioral change in IndexWriteStage

`IndexWriteStage.run()` previously returned `success=True` (swallowing the error silently) when embedding raised. It now returns `success=False` with the error message, and no snapshot is written on failure. This is a correctness fix — callers that handled `success=True` with zero chunks added should now handle `success=False` with `error` set.

## Branch

`development` -> `main`